### PR TITLE
ci: pin Go toolchain to 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version: "1.25.13"
 
       - name: Build
         run: go build ./...
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version: "1.25.13"
 
       - name: Run tests
         run: go test ./... -race -cover -coverprofile=coverage.out


### PR DESCRIPTION
Pins `actions/setup-go` to `1.25.13` to resolve `govulncheck` failures caused by standard-library vulnerabilities present in `go1.25.12` (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026).