### PR TITLE
fix(ocr): repair MG, VS, and Power extractor misreads

### DIFF
--- a/main.go
+++ b/main.go
@@ -7553,6 +7553,9 @@ func parsePowerRankingsText(text string) []struct {
 			name := strings.TrimSpace(matches[1])
 			// Clean up extra whitespace in names
 			name = regexp.MustCompile(`\s+`).ReplaceAllString(name, " ")
+			// Strip rank-badge glyphs that OCR misreads into the start of a name
+			// (e.g. "Ra Mochinas", "Re ryukyuki", "oy cS RS kili").
+			name = stripPowerRankBadge(name)
 
 			powerStr := strings.ReplaceAll(matches[2], ",", "")
 			powerStr = strings.ReplaceAll(powerStr, " ", "")
@@ -7592,7 +7595,53 @@ func parsePowerRankingsText(text string) []struct {
 		}
 	}
 
-	return records
+	return stripPowerTrailingPins(records)
+}
+
+// stripPowerRankBadge removes OCR misreads of the rank badge (R1–R5) that leak
+// into the start of a player name. The badge renders as short 2-char tokens
+// ("Ra", "Re", "Ri", "Ly", "RI", "oy cS RS") immediately before the real name.
+func stripPowerRankBadge(name string) string {
+	fields := strings.Fields(name)
+	stripped := 0
+	for len(fields) > 1 && stripped < 3 {
+		if len(fields[0]) == 2 {
+			fields = fields[1:]
+			stripped++
+			continue
+		}
+		break
+	}
+	// Only keep the stripped result when a plausible (>=3 char) name token remains.
+	if len(fields) > 0 && len(fields[0]) >= 3 {
+		return strings.Join(fields, " ")
+	}
+	return name
+}
+
+// stripPowerTrailingPins drops records that break the strictly-descending power
+// ordering. The pinned "you" row (the viewer's own rank) is always rendered at
+// the bottom of every screenshot with the same high power value, so it appears
+// as a trailing record whose power is greater than the rank above it.
+func stripPowerTrailingPins(records []struct {
+	MemberName string `json:"member_name"`
+	Power      int64  `json:"power"`
+}) []struct {
+	MemberName string `json:"member_name"`
+	Power      int64  `json:"power"`
+} {
+	out := make([]struct {
+		MemberName string `json:"member_name"`
+		Power      int64  `json:"power"`
+	}, 0, len(records))
+	for _, r := range records {
+		if len(out) > 0 && r.Power > out[len(out)-1].Power {
+			log.Printf("Power OCR: dropping out-of-order record %s=%d (pinned 'you' row or OCR misread)", r.MemberName, r.Power)
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // extractPowerByRows segments the power rankings screenshot into individual rows
@@ -8772,8 +8821,12 @@ func mergeVSRecordsByName(primary []VSOCRRecord, supplemental []VSOCRRecord) []V
 		return primary
 	}
 	seen := map[string]bool{}
+	seenPoints := map[int64]bool{}
 	for _, r := range primary {
 		seen[normalizeName(r.MemberName)] = true
+		if r.Points > 0 {
+			seenPoints[r.Points] = true
+		}
 	}
 	for _, r := range supplemental {
 		r.MemberName = cleanVSRowName(r.MemberName)
@@ -8784,10 +8837,19 @@ func mergeVSRecordsByName(primary []VSOCRRecord, supplemental []VSOCRRecord) []V
 		if key == "" || seen[key] {
 			continue
 		}
+		// Each rank in a single screenshot has a unique points value. A repeated
+		// value means the full-image fallback re-read an already-extracted row
+		// under a mis-OCR'd alias name — skip it.
+		if r.Points > 0 && seenPoints[r.Points] {
+			continue
+		}
 		r.Confidence = "review"
 		r.Notes = append(r.Notes, "added from full-image OCR fallback")
 		primary = append(primary, r)
 		seen[key] = true
+		if r.Points > 0 {
+			seenPoints[r.Points] = true
+		}
 		log.Printf("VS OCR supplemental full-image record: %s -> %d", r.MemberName, r.Points)
 	}
 	return primary

--- a/mg_ocr.go
+++ b/mg_ocr.go
@@ -991,5 +991,110 @@ func mgProcessImage(imageData []byte) (*MGImgResult, error) {
 		return result.Members[i].Rank < result.Members[j].Rank
 	})
 
+	// Fallback date extraction: the colour-segmentation heuristic above misses the
+	// datetime line on many screenshots. Recover it with a proportional center crop
+	// near the bottom of the mail body (same approach used by extractMGByMask).
+	if result.EventDate == "" {
+		result.EventDate = mgExtractEventDate(img, width, height)
+	}
+
+	// Fix dropped-decimal damage values (e.g. "152G" OCR'd instead of "1.52G") by
+	// detecting implausible outliers against nearby ranks.
+	mgFixDamageOutliers(result.Members)
+
+	// The MVP (top card) always out-damages every listed member. If the extracted
+	// top damage is below the highest member damage, the top card was misread —
+	// discard it rather than report a wrong value.
+	if result.TopPlayerDmgInt > 0 {
+		maxMember := int64(0)
+		for _, m := range result.Members {
+			if m.DamageInt > maxMember {
+				maxMember = m.DamageInt
+			}
+		}
+		if maxMember > 0 && result.TopPlayerDmgInt < maxMember {
+			log.Printf("mg_ocr: top card implausible (%d < max member %d), discarding", result.TopPlayerDmgInt, maxMember)
+			result.TopPlayerName = ""
+			result.TopPlayerDmgStr = ""
+			result.TopPlayerDmgInt = 0
+		}
+	}
+
 	return result, nil
+}
+
+// mgExtractEventDate extracts the event date from the full MG mail screenshot
+// using a proportional center crop near the bottom of the mail body.
+func mgExtractEventDate(img image.Image, width, height int) string {
+	x0 := int(float64(width) * 0.15)
+	x1 := int(float64(width) * 0.85)
+	y0 := int(float64(height) * 0.88)
+	y1 := int(float64(height) * 0.91)
+	if y1-y0 < 8 {
+		y1 = y0 + 8
+	}
+	if x1 <= x0 || y1 <= y0 || y1 > height || x1 > width {
+		return ""
+	}
+	rect := mgRect{x0: x0, y0: y0, x1: x1, y1: y1}
+	dateRe := regexp.MustCompile(`(\d{4})-(\d{1,2})-(\d{1,2})`)
+	for _, mode := range []int{0, 1, 2} {
+		data, err := mgCropAndBinarize(img, rect, mode)
+		if err != nil {
+			continue
+		}
+		raw, err := mgRunOCR(data, gosseract.PSM_SINGLE_LINE, "")
+		if err != nil {
+			continue
+		}
+		log.Printf("mg_ocr: date fallback mode=%d raw OCR: %q", mode, raw)
+		if m := dateRe.FindStringSubmatch(raw); m != nil {
+			y, _ := strconv.Atoi(m[1])
+			mo, _ := strconv.Atoi(m[2])
+			d, _ := strconv.Atoi(m[3])
+			if y >= 2000 && y <= 2100 && mo >= 1 && mo <= 12 && d >= 1 && d <= 31 {
+				return fmt.Sprintf("%04d-%02d-%02d", y, mo, d)
+			}
+		}
+	}
+	return ""
+}
+
+// mgFixDamageOutliers repairs damage values whose decimal point was dropped by
+// OCR (e.g. "152G" read from "1.52G"). A dropped decimal makes the value ~100×
+// (or ~1000×) the neighbouring ranks, so we divide it back when it is a clear
+// outlier against nearby valid values.
+func mgFixDamageOutliers(members []mgMemberOCR) {
+	for i := range members {
+		if !members[i].DamageOK || members[i].DamageInt <= 0 {
+			continue
+		}
+		var refs []int64
+		for j := range members {
+			if j == i || !members[j].DamageOK || members[j].DamageInt <= 0 {
+				continue
+			}
+			if absInt64(int64(members[j].Rank-members[i].Rank)) <= 5 {
+				refs = append(refs, members[j].DamageInt)
+			}
+		}
+		if len(refs) == 0 {
+			continue
+		}
+		sort.Slice(refs, func(a, b int) bool { return refs[a] < refs[b] })
+		median := refs[len(refs)/2]
+		if median <= 0 {
+			continue
+		}
+		v := members[i].DamageInt
+		for v >= median*50 {
+			v /= 100
+		}
+		if v != members[i].DamageInt {
+			log.Printf("mg_ocr: damage outlier repair rank %d: %d -> %d", members[i].Rank, members[i].DamageInt, v)
+			members[i].DamageInt = v
+			members[i].DamageStr = mgFormatDamageStr(v)
+			members[i].DamageOK = true
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Validated the existing OCR extractors against the real screenshots in `screenshots/` and fixed the concrete misreads found.

## Fixes

**Marshal Guard (`mg_ocr.go`)**
- Added fallback event-date extraction via proportional center crop near the bottom of the mail body (the colour-segmentation heuristic missed the datetime line on most shots).
- Repaired dropped-decimal damage values (`152G` read from `1.52G`) by dividing clear outliers against nearby ranks.
- Discarded implausible top-card value when it falls below the highest member damage.

**Alliance Duel / VS (`main.go`)**
- Deduped full-image fallback records by shared points value — each rank has a unique points value, so a repeated value means the fallback re-read an already-extracted row under a mis-OCR'd alias.

**Power / Strength Ranking (`main.go`)**
- Stripped rank-badge glyphs leaking into name starts (`Ra Mochinas`, `Re ryukyuki`, `oy cS RS kili`).
- Dropped the pinned "you" row, which rendered at the bottom of every screenshot with the same high power value and broke the strictly-descending order.

## Verification

- `go build ./...` passes
- `go test ./...` passes
- Harness validated against all real screenshots (date `2026-08-07` on all 10 MG images, VS duplicates removed, Power badge/pin fixed)