### PR TITLE
feat: add Desert Storm and Zombie Siege event tracking with OCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 alliance-manager
 alliance-manager.exe
+lastwar-alliance
 *.exe
 *.dll
 *.so

--- a/main.go
+++ b/main.go
@@ -8216,9 +8216,49 @@ func extractDesertStormDataFromImage(imageData []byte) ([]DSOCRRecord, string, e
 // The metric is individual waves defended (a small integer), not the 8-digit
 // power/score printed beneath the name.
 type ZSOCRRecord struct {
-	MemberName  string `json:"member_name"`
-	AllianceTag string `json:"alliance_tag"`
-	Waves       int64  `json:"waves"`
+	MemberName  string   `json:"member_name"`
+	AllianceTag string   `json:"alliance_tag"`
+	Waves       int64    `json:"waves"`
+	Warnings    []string `json:"warnings,omitempty"`
+}
+
+// Warning messages surfaced in the OCR preview so users can fix weak reads.
+const (
+	zsWaveWarning = "Wave count unreadable by OCR — verify"
+	zsNameWarning = "Name may be OCR garbage — verify"
+)
+
+// zsNameLooksLikeJunk flags multi-word names whose tokens are all short
+// ("Pte iit itt"); real multi-word names ("Theodore Silas") have tokens of
+// at least four chars. Single-word names pass (short names like "evil" exist).
+func zsNameLooksLikeJunk(name string) bool {
+	parts := strings.Fields(name)
+	if len(parts) < 2 {
+		return false
+	}
+	for _, p := range parts {
+		if len(p) < 4 {
+			return true
+		}
+	}
+	return false
+}
+
+// zsMergeWarnings unions warnings from two OCR reads of the same player,
+// dropping the wave warning once a legible wave count exists.
+func zsMergeWarnings(a, b []string, waves int64) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, w := range append(append([]string{}, a...), b...) {
+		if w == zsWaveWarning && waves > 0 {
+			continue
+		}
+		if !seen[w] {
+			seen[w] = true
+			out = append(out, w)
+		}
+	}
+	return out
 }
 
 // parseZSWave recognises a small integer wave count (individual waves defended
@@ -8543,6 +8583,14 @@ func extractZombieSiegeDataFromImage(imageData []byte) ([]ZSOCRRecord, string, e
 	records := names[:n]
 	for i := 0; i < n; i++ {
 		records[i].Waves = waves[i]
+	}
+	for i := range records {
+		if zsNameLooksLikeJunk(records[i].MemberName) {
+			records[i].Warnings = append(records[i].Warnings, zsNameWarning)
+		}
+		if records[i].Waves == 0 {
+			records[i].Warnings = append(records[i].Warnings, zsWaveWarning)
+		}
 	}
 
 	sort.SliceStable(records, func(i, j int) bool {
@@ -11882,12 +11930,13 @@ type ZombieSiegeOCRResult struct {
 }
 
 type ZSOCRParticipant struct {
-	RankInEvent  int    `json:"rank_in_event"`
-	NameSnapshot string `json:"name_snapshot"`
-	AllianceTag  string `json:"alliance_tag"`
-	Waves        int64  `json:"waves"`
-	MemberID     *int   `json:"member_id"`
-	MemberName   string `json:"member_name,omitempty"`
+	RankInEvent  int      `json:"rank_in_event"`
+	NameSnapshot string   `json:"name_snapshot"`
+	AllianceTag  string   `json:"alliance_tag"`
+	Waves        int64    `json:"waves"`
+	MemberID     *int     `json:"member_id"`
+	MemberName   string   `json:"member_name,omitempty"`
+	Warnings     []string `json:"warnings,omitempty"`
 }
 
 type ZSConfirmRequest struct {
@@ -12302,6 +12351,7 @@ func processZombieSiegeScreenshots(w http.ResponseWriter, r *http.Request) {
 				NameSnapshot: rec.MemberName,
 				AllianceTag:  rec.AllianceTag,
 				Waves:        rec.Waves,
+				Warnings:     rec.Warnings,
 			}
 			merged := false
 			for i, existing := range allParticipants {
@@ -12311,6 +12361,7 @@ func processZombieSiegeScreenshots(w http.ResponseWriter, r *http.Request) {
 						allParticipants[i].Waves = p.Waves
 						allParticipants[i].AllianceTag = p.AllianceTag
 					}
+					allParticipants[i].Warnings = zsMergeWarnings(existing.Warnings, p.Warnings, allParticipants[i].Waves)
 					merged = true
 					break
 				}

--- a/main.go
+++ b/main.go
@@ -7750,6 +7750,376 @@ func repairPowerSingleDigit(power, prev, next, prior int64) (int64, bool) {
 	return best, true
 }
 
+// ── Desert Storm ─────────────────────────────────────────────────────────────
+
+// DSOCRRecord is a single Desert Storm ranking row extracted from a screenshot.
+type DSOCRRecord struct {
+	MemberName  string `json:"member_name"`
+	AllianceTag string `json:"alliance_tag"`
+	Damage      int64  `json:"damage"`
+}
+
+// dsHeaderNoise lists substrings that mark Desert Storm UI header/decoration
+// lines and must be dropped before name/damage parsing.
+var dsHeaderNoise = []string{
+	"desert", "storm", "battle", "result", "individual", "point",
+	"ranking", "commander", "wave", "report", "congrat", "defend",
+	"stronghold", "suppl",
+}
+
+func dsContainsNoise(line string) bool {
+	lower := strings.ToLower(line)
+	for _, n := range dsHeaderNoise {
+		if strings.Contains(lower, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// dsIsDigits reports whether s contains only ASCII digits.
+func dsIsDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// parseDSNumber recognises a standalone damage line. DS damage can be "0"
+// (bottom ranks) up to ~10 digits. A candidate must already be digit-dominant
+// before any correction, so player-name lines (mostly letters) are never
+// mistaken for numbers; common OCR letter misreads are then corrected.
+func parseDSNumber(line string) (int64, bool) {
+	s := strings.TrimSpace(line)
+	if s == "" {
+		return 0, false
+	}
+	s = strings.TrimRight(s, ".,;:|")
+	s = strings.ReplaceAll(s, ",", "")
+	s = strings.ReplaceAll(s, " ", "")
+	if s == "" {
+		return 0, false
+	}
+	digits := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			digits++
+		}
+	}
+	if digits == 0 || digits < len(s)-digits {
+		return 0, false
+	}
+	s = strings.NewReplacer(
+		"O", "0", "o", "0", "S", "5", "s", "5", "l", "1", "I", "1",
+		"Z", "2", "B", "8", "b", "6", "G", "6", "g", "9", "e", "6",
+	).Replace(s)
+	s = regexp.MustCompile(`[^0-9]`).ReplaceAllString(s, "")
+	if s == "" || len(s) > 10 {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// parseDesertStormText parses OCR text from the (left-column-trimmed) Desert
+// Storm data region. The ranking list renders "[TAG]Name" with the damage
+// number beneath it, so the parser pairs a name line with a following number
+// line. It also tolerates OCR joining them into a single "name number" line
+// when the trailing number is large (5+ digits — player names never end in
+// more than 4 digits).
+func parseDesertStormText(text string) ([]DSOCRRecord, string) {
+	var records []DSOCRRecord
+	eventDate := ""
+	knownTag := getAllianceShortName()
+
+	dateRe := regexp.MustCompile(`(\d{4})[-/](\d{1,2})[-/](\d{1,2})`)
+	sameLineRe := regexp.MustCompile(`^(.+?)\s+(\d{5,10})\s*[.,]?$`)
+
+	var pendingName, pendingTag string
+	emit := func() {
+		if pendingName != "" {
+			records = append(records, DSOCRRecord{MemberName: pendingName, AllianceTag: pendingTag, Damage: 0})
+		}
+	}
+
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+
+		// Event date from the trailing timestamp ("2026-8-7 23:30:12").
+		if eventDate == "" {
+			if m := dateRe.FindStringSubmatch(line); m != nil {
+				eventDate = m[1] + "-" + m[2] + "-" + m[3]
+			}
+		}
+
+		// Skip timestamp and header/decoration lines.
+		if dateRe.MatchString(strings.TrimSpace(line)) && !strings.Contains(line, " ") {
+			continue
+		}
+		if strings.HasPrefix(line, "202") && strings.Contains(line, ":") {
+			continue
+		}
+		if dsContainsNoise(line) {
+			continue
+		}
+
+		// Same-line "name number" (large trailing number).
+		if m := sameLineRe.FindStringSubmatch(line); m != nil {
+			if num, ok := parseDSNumber(m[2]); ok {
+				tag, nameOnly := parsePlayerTag(m[1], knownTag)
+				nameOnly = strings.TrimSpace(nameOnly)
+				if len(nameOnly) >= 2 {
+					records = append(records, DSOCRRecord{MemberName: nameOnly, AllianceTag: tag, Damage: num})
+					pendingName, pendingTag = "", ""
+					continue
+				}
+			}
+		}
+
+		// Standalone number line → damage for the pending name.
+		if num, ok := parseDSNumber(line); ok {
+			if pendingName != "" {
+				records = append(records, DSOCRRecord{MemberName: pendingName, AllianceTag: pendingTag, Damage: num})
+				pendingName, pendingTag = "", ""
+			}
+			continue
+		}
+
+		// Otherwise treat as a name line (replaces any un-paired pending name,
+		// which happens with OCR garbage like "eitithel Pots" before the list).
+		tag, nameOnly := parsePlayerTag(line, knownTag)
+		nameOnly = strings.TrimSpace(nameOnly)
+		if len(nameOnly) >= 2 {
+			pendingName, pendingTag = nameOnly, tag
+		}
+	}
+	emit()
+
+	// Dedupe by name (keep first occurrence — the higher rank / damage).
+	seen := map[string]bool{}
+	out := records[:0]
+	for _, r := range records {
+		key := strings.ToLower(r.MemberName)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, r)
+	}
+
+	// Drop any trailing record that never got a damage value paired.
+	final := out[:0]
+	for _, r := range out {
+		if r.Damage > 0 || r.MemberName != "" {
+			final = append(final, r)
+		}
+	}
+	return final, eventDate
+}
+
+// parseDesertStormWords builds Desert Storm records from tesseract word boxes.
+// The ranking list left-aligns "[TAG]Name" with the damage number on the line
+// directly beneath it, both at ~10.5% of the crop width. Words left of that
+// column (rank-number/avatar artwork) and right of it (header/decoration/
+// timestamp) are noise, so grouping words into lines and classifying by the
+// alignment column plus digit content avoids the plain-text parser's misreads
+// (split damage numbers, leaked rank badges, joined "name number" lines).
+func parseDesertStormWords(boxes []gosseract.BoundingBox, cropWidth int) ([]DSOCRRecord, string) {
+	var records []DSOCRRecord
+	knownTag := getAllianceShortName()
+	dateRe := regexp.MustCompile(`(\d{4})[-/](\d{1,2})[-/](\d{1,2})`)
+	eventDate := ""
+
+	if cropWidth <= 0 {
+		cropWidth = 1
+	}
+	minListX := cropWidth * 95 / 1000
+	maxListX := cropWidth * 160 / 1000
+
+	type word struct {
+		text string
+		x, y int
+	}
+	var words []word
+	for _, b := range boxes {
+		s := strings.TrimSpace(b.Word)
+		if s == "" {
+			continue
+		}
+		if eventDate == "" {
+			if m := dateRe.FindStringSubmatch(s); m != nil {
+				eventDate = m[1] + "-" + m[2] + "-" + m[3]
+			}
+		}
+		if b.Box.Min.X < minListX && !dsIsDigits(s) {
+			// Left of the name/damage column: keep only pure-digit
+			// fragments (leading digits of a split damage number hidden
+			// under rank/avatar artwork). Drop rank badges and other noise.
+			continue
+		}
+		words = append(words, word{text: s, x: b.Box.Min.X, y: b.Box.Min.Y})
+	}
+
+	sort.SliceStable(words, func(i, j int) bool {
+		if words[i].y != words[j].y {
+			return words[i].y < words[j].y
+		}
+		return words[i].x < words[j].x
+	})
+
+	type line struct {
+		text string
+		x    int
+	}
+	// Group words into visual lines: names and damages sit ~104px apart
+	// vertically, while a multi-word name varies by only a few px.
+	var wordLines [][]word
+	for _, w := range words {
+		if len(wordLines) == 0 || w.y-wordLines[len(wordLines)-1][0].y > 40 {
+			wordLines = append(wordLines, []word{w})
+			continue
+		}
+		wordLines[len(wordLines)-1] = append(wordLines[len(wordLines)-1], w)
+	}
+	var lines []line
+	for _, ws := range wordLines {
+		// Order left-to-right so a split "[TAG] name" joins correctly even
+		// when OCR boxes sit at slightly different y.
+		sort.SliceStable(ws, func(i, j int) bool { return ws[i].x < ws[j].x })
+		var sb strings.Builder
+		for i, w := range ws {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(w.text)
+		}
+		lines = append(lines, line{text: sb.String(), x: ws[0].x})
+	}
+
+	var pendingName, pendingTag string
+	for _, l := range lines {
+		if l.x > maxListX {
+			continue // header/decoration or right-side noise
+		}
+		if n, ok := parseDSNumber(l.text); ok {
+			if pendingName != "" {
+				records = append(records, DSOCRRecord{MemberName: pendingName, AllianceTag: pendingTag, Damage: n})
+				pendingName, pendingTag = "", ""
+			}
+			continue
+		}
+		tag, nameOnly := parsePlayerTag(l.text, knownTag)
+		nameOnly = strings.TrimSpace(nameOnly)
+		if len(nameOnly) >= 2 {
+			pendingName, pendingTag = nameOnly, tag
+		}
+	}
+
+	// Dedupe by name (first occurrence = higher rank/damage).
+	seen := map[string]bool{}
+	out := records[:0]
+	for _, r := range records {
+		key := strings.ToLower(r.MemberName)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, r)
+	}
+	return out, eventDate
+}
+
+// extractDesertStormDataFromImage OCRs a Desert Storm battle-results
+// screenshot. It crops to the data region, drops the left ~33% avatar/rank
+// artwork (which produces noise), and parses the left-aligned ranking list.
+// Returns records sorted by damage descending plus the detected event date.
+func extractDesertStormDataFromImage(imageData []byte) ([]DSOCRRecord, string, error) {
+	img, _, err := image.Decode(bytes.NewReader(imageData))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to decode image: %v", err)
+	}
+
+	attrs := analyzeScreenshot(img)
+	if attrs.DataRegion == nil || attrs.Width <= 0 {
+		return nil, "", fmt.Errorf("could not analyze screenshot")
+	}
+
+	cropLeft := attrs.Width * 33 / 100
+	cropRight := attrs.Width
+	cropTop := attrs.DataRegion.Top
+	cropBottom := attrs.DataRegion.Bottom
+	if cropBottom > attrs.Height {
+		cropBottom = attrs.Height
+	}
+	if cropTop >= cropBottom || cropRight <= cropLeft {
+		return nil, "", fmt.Errorf("invalid crop region")
+	}
+
+	crop := image.NewRGBA(image.Rect(0, 0, cropRight-cropLeft, cropBottom-cropTop))
+	draw.Draw(crop, crop.Bounds(), img, image.Point{cropLeft, cropTop}, draw.Src)
+
+	gray := convertToGrayscale(scaleImage(crop, 2))
+	crop2xWidth := gray.Bounds().Dx()
+	data, err := encodePNGBytes(gray)
+	if err != nil {
+		return nil, "", err
+	}
+
+	client := gosseract.NewClient()
+	defer client.Close()
+	if err := client.SetImageFromBytes(data); err != nil {
+		return nil, "", fmt.Errorf("failed to load image: %v", err)
+	}
+
+	var records []DSOCRRecord
+	var eventDate string
+
+	// Primary path: word boxes carry spatial layout, so split damage numbers
+	// and leaked rank-badge noise can be filtered by position.
+	for _, mode := range []gosseract.PageSegMode{gosseract.PSM_AUTO, gosseract.PSM_SPARSE_TEXT, gosseract.PSM_SINGLE_BLOCK} {
+		client.SetPageSegMode(mode)
+		boxes, err := client.GetBoundingBoxes(gosseract.RIL_WORD)
+		if err != nil || len(boxes) == 0 {
+			continue
+		}
+		records, eventDate = parseDesertStormWords(boxes, crop2xWidth)
+		if len(records) > 0 {
+			break
+		}
+	}
+
+	// Fallback: plain text for older/quirky layouts where word boxes fail.
+	if len(records) == 0 {
+		for _, mode := range []gosseract.PageSegMode{gosseract.PSM_SINGLE_BLOCK, gosseract.PSM_AUTO, gosseract.PSM_SPARSE_TEXT} {
+			client.SetPageSegMode(mode)
+			if t, err := client.Text(); err == nil && len(strings.TrimSpace(t)) > 0 {
+				records, eventDate = parseDesertStormText(t)
+				if len(records) > 0 {
+					break
+				}
+			}
+		}
+	}
+
+	if len(records) == 0 {
+		return nil, eventDate, fmt.Errorf("no valid records found in Desert Storm screenshot")
+	}
+
+	sort.SliceStable(records, func(i, j int) bool { return records[i].Damage > records[j].Damage })
+	return records, eventDate, nil
+}
+
 // extractPowerByRows segments the power rankings screenshot into individual rows
 // using edge-based separator detection and OCRs each name+power cell separately.
 //
@@ -12073,6 +12443,14 @@ func loadAllMembers() ([]Member, error) {
 // parsePlayerTag extracts the alliance tag and plain player name from strings like
 // "[RSRP]Gargoland" or "[RSRPlJazzyopolis" (where ] was OCR'd as l, 1, | or I).
 // knownTag (from settings) is used for fuzzy bracket matching before standard parsing.
+// getAllianceShortName returns the uppercase alliance short name from settings,
+// used as the known tag hint for player-tag parsing.
+func getAllianceShortName() string {
+	var tag string
+	db.QueryRow(`SELECT COALESCE(alliance_short_name, '') FROM settings WHERE id = 1`).Scan(&tag)
+	return strings.ToUpper(strings.TrimSpace(tag))
+}
+
 func parsePlayerTag(name, knownTag string) (tag, nameOnly string) {
 	name = strings.TrimSpace(name)
 	// Prefer known-tag match with fuzzy closing bracket.

--- a/main.go
+++ b/main.go
@@ -8082,7 +8082,7 @@ func parseDesertStormWords(boxes []gosseract.BoundingBox, cropWidth int) ([]DSOC
 		}
 		wordLines[len(wordLines)-1] = append(wordLines[len(wordLines)-1], w)
 	}
-	var lines []line
+	lines := make([]line, 0, len(wordLines))
 	for _, ws := range wordLines {
 		// Order left-to-right so a split "[TAG] name" joins correctly even
 		// when OCR boxes sit at slightly different y.

--- a/main.go
+++ b/main.go
@@ -8265,6 +8265,20 @@ func parseZSWave(line string) (int64, bool) {
 	return n, true
 }
 
+// zsValidName rejects OCR junk that lands in the name column: rank/avatar
+// glyphs read as single symbols ("|", "=", "_"), two-letter fragments ("BY",
+// "Gy", "oe"), or merged junk like "= = oe". A real player name contains at
+// least three letters.
+func zsValidName(s string) bool {
+	letters := 0
+	for _, c := range strings.TrimSpace(s) {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			letters++
+		}
+	}
+	return letters >= 3
+}
+
 // zsParseNames extracts player names from full-width word boxes. Names sit at
 // ~33% of width, the 8-digit power at ~40% (dropped as pure digits), and the
 // alliance tag / rank badge left of ~30% or just below the name. The column
@@ -8288,7 +8302,8 @@ func zsParseNames(boxes []gosseract.BoundingBox, cropWidth int) ([]ZSOCRRecord, 
 	}
 
 	nameMinX := cropWidth * 30 / 100
-	nameMaxX := cropWidth * 42 / 100
+	nameMaxX := cropWidth * 42 / 100  // a new row's name starts within this column
+	nameContX := cropWidth * 60 / 100 // hard right bound for same-line continuation
 
 	type word struct {
 		text string
@@ -8326,7 +8341,7 @@ func zsParseNames(boxes []gosseract.BoundingBox, cropWidth int) ([]ZSOCRRecord, 
 		if w.y <= headerY+20 {
 			continue
 		}
-		if w.x < nameMinX || w.x > nameMaxX {
+		if w.x < nameMinX || w.x > nameContX {
 			continue
 		}
 		if dateRe.MatchString(w.text) || strings.Contains(w.text, ":") {
@@ -8336,6 +8351,11 @@ func zsParseNames(boxes []gosseract.BoundingBox, cropWidth int) ([]ZSOCRRecord, 
 			continue // power/score value beneath the name
 		}
 		if len(lines) == 0 || w.y-lines[len(lines)-1].y > 25 {
+			// A new row only starts inside the name column; words to the right
+			// of it (multi-word name tails like "Silas") only extend a row.
+			if w.x > nameMaxX {
+				continue
+			}
 			lines = append(lines, line{text: w.text, y: w.y})
 			continue
 		}
@@ -8350,7 +8370,11 @@ func zsParseNames(boxes []gosseract.BoundingBox, cropWidth int) ([]ZSOCRRecord, 
 		if l.y-lastY <= 200 {
 			continue
 		}
-		names = append(names, ZSOCRRecord{MemberName: strings.TrimSpace(l.text)})
+		name := strings.TrimSpace(l.text)
+		if !zsValidName(name) {
+			continue
+		}
+		names = append(names, ZSOCRRecord{MemberName: name})
 		lastY = l.y
 	}
 

--- a/main.go
+++ b/main.go
@@ -246,6 +246,7 @@ type Settings struct {
 	VipSeatEnabled               bool   `json:"vip_seat_enabled"`
 	MarshalGuardEnabled          bool   `json:"marshal_guard_enabled"`
 	DesertStormEnabled           bool   `json:"desert_storm_enabled"`
+	ZombieSiegeEnabled           bool   `json:"zombie_siege_enabled"`
 }
 
 type MemberRanking struct {
@@ -1897,6 +1898,17 @@ Ask in alliance chat for the train to be assigned. Thanks for keeping the train 
 		log.Println("Database migration: Added desert_storm_enabled column to settings table")
 	}
 
+	// Migrate settings table to add zombie_siege_enabled column if missing
+	var zsEnabledColumnExists bool
+	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('settings') WHERE name='zombie_siege_enabled'`).Scan(&zsEnabledColumnExists)
+	if err != nil || !zsEnabledColumnExists {
+		_, err = db.Exec(`ALTER TABLE settings ADD COLUMN zombie_siege_enabled INTEGER NOT NULL DEFAULT 1`)
+		if err != nil {
+			return err
+		}
+		log.Println("Database migration: Added zombie_siege_enabled column to settings table")
+	}
+
 	// Create marshal_guard_events table
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS marshal_guard_events (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1949,6 +1961,35 @@ Ask in alliance chat for the train to be assigned. Thanks for keeping the train 
 		alliance_tag TEXT,
 		rank_in_event INTEGER NOT NULL,
 		damage INTEGER NOT NULL DEFAULT 0,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(event_id, rank_in_event)
+	)`)
+	if err != nil {
+		return err
+	}
+
+	// Create zombie_siege_events table (waves-defended ranking)
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS zombie_siege_events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_date TEXT NOT NULL,
+		total_waves INTEGER NOT NULL DEFAULT 0,
+		notes TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		created_by_id INTEGER REFERENCES users(id)
+	)`)
+	if err != nil {
+		return err
+	}
+
+	// Create zombie_siege_participants table
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS zombie_siege_participants (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_id INTEGER NOT NULL REFERENCES zombie_siege_events(id) ON DELETE CASCADE,
+		member_id INTEGER REFERENCES members(id),
+		name_snapshot TEXT NOT NULL,
+		alliance_tag TEXT,
+		rank_in_event INTEGER NOT NULL,
+		waves INTEGER NOT NULL DEFAULT 0,
 		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 		UNIQUE(event_id, rank_in_event)
 	)`)
@@ -4818,7 +4859,8 @@ func getSettings(w http.ResponseWriter, r *http.Request) {
 		COALESCE(min_hq_level, 0) as min_hq_level,
 		COALESCE(vip_seat_enabled, 1) as vip_seat_enabled,
 		COALESCE(marshal_guard_enabled, 1) as marshal_guard_enabled,
-		COALESCE(desert_storm_enabled, 1) as desert_storm_enabled
+		COALESCE(desert_storm_enabled, 1) as desert_storm_enabled,
+		COALESCE(zombie_siege_enabled, 1) as zombie_siege_enabled
 		FROM settings WHERE id = 1`).Scan(
 		&settings.ID,
 		&settings.AllianceName,
@@ -4845,6 +4887,7 @@ func getSettings(w http.ResponseWriter, r *http.Request) {
 		&settings.VipSeatEnabled,
 		&settings.MarshalGuardEnabled,
 		&settings.DesertStormEnabled,
+		&settings.ZombieSiegeEnabled,
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -4897,7 +4940,8 @@ func updateSettings(w http.ResponseWriter, r *http.Request) {
 		min_hq_level = ?,
 		vip_seat_enabled = ?,
 		marshal_guard_enabled = ?,
-		desert_storm_enabled = ?
+		desert_storm_enabled = ?,
+		zombie_siege_enabled = ?
 		WHERE id = 1`,
 		settings.AllianceName,
 		settings.AllianceShortName,
@@ -4923,6 +4967,7 @@ func updateSettings(w http.ResponseWriter, r *http.Request) {
 		settings.VipSeatEnabled,
 		settings.MarshalGuardEnabled,
 		settings.DesertStormEnabled,
+		settings.ZombieSiegeEnabled,
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -8162,6 +8207,326 @@ func extractDesertStormDataFromImage(imageData []byte) ([]DSOCRRecord, string, e
 	}
 
 	sort.SliceStable(records, func(i, j int) bool { return records[i].Damage > records[j].Damage })
+	return records, eventDate, nil
+}
+
+// ── Zombie Siege ────────────────────────────────────────────────────────────
+
+// ZSOCRRecord is a single Zombie Siege ranking row extracted from a screenshot.
+// The metric is individual waves defended (a small integer), not the 8-digit
+// power/score printed beneath the name.
+type ZSOCRRecord struct {
+	MemberName  string `json:"member_name"`
+	AllianceTag string `json:"alliance_tag"`
+	Waves       int64  `json:"waves"`
+}
+
+// parseZSWave recognises a small integer wave count (individual waves defended
+// are single/double digit; totals stay far below 100000). It is stricter than
+// parseDSNumber: any character outside the digit/misread set rejects the token,
+// so decimal-power values like "37.3M" and "2.2K" are never mistaken for a wave.
+func parseZSWave(line string) (int64, bool) {
+	s := strings.TrimSpace(line)
+	if s == "" {
+		return 0, false
+	}
+	s = strings.TrimRight(s, ".,;:|")
+	s = strings.ReplaceAll(s, ",", "")
+	s = strings.ReplaceAll(s, " ", "")
+	if s == "" {
+		return 0, false
+	}
+	digits := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			digits++
+		} else if !strings.ContainsRune("OoSslIZBbGge", c) {
+			return 0, false
+		}
+	}
+	if digits == 0 {
+		return 0, false
+	}
+	s = strings.NewReplacer(
+		"O", "0", "o", "0", "S", "5", "s", "5", "l", "1", "I", "1",
+		"Z", "2", "B", "8", "b", "6", "G", "6", "g", "9", "e", "6",
+	).Replace(s)
+	s = regexp.MustCompile(`[^0-9]`).ReplaceAllString(s, "")
+	if s == "" || len(s) > 5 {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	if n >= 100000 {
+		return 0, false // power/score column leak, never a wave count
+	}
+	return n, true
+}
+
+// zsParseNames extracts player names from full-width word boxes. Names sit at
+// ~33% of width, the 8-digit power at ~40% (dropped as pure digits), and the
+// alliance tag / rank badge left of ~30% or just below the name. The column
+// header row ("Ranking | Commander | Wave") marks the top of the data region;
+// everything above it is header text.
+func zsParseNames(boxes []gosseract.BoundingBox, cropWidth int) ([]ZSOCRRecord, string) {
+	dateRe := regexp.MustCompile(`(\d{4})[-/](\d{1,2})[-/](\d{1,2})`)
+	eventDate := ""
+	if cropWidth <= 0 {
+		cropWidth = 1
+	}
+
+	headerY := 0
+	for _, b := range boxes {
+		lw := strings.ToLower(strings.TrimSpace(b.Word))
+		if strings.Contains(lw, "commander") || strings.Contains(lw, "ranking") || strings.Contains(lw, "wave") {
+			if b.Box.Min.Y > headerY {
+				headerY = b.Box.Min.Y
+			}
+		}
+	}
+
+	nameMinX := cropWidth * 30 / 100
+	nameMaxX := cropWidth * 42 / 100
+
+	type word struct {
+		text string
+		x, y int
+	}
+	var words []word
+	for _, b := range boxes {
+		s := strings.TrimSpace(b.Word)
+		if s == "" {
+			continue
+		}
+		if eventDate == "" {
+			if m := dateRe.FindStringSubmatch(s); m != nil {
+				eventDate = m[1] + "-" + m[2] + "-" + m[3]
+			}
+		}
+		words = append(words, word{text: s, x: b.Box.Min.X, y: b.Box.Min.Y})
+	}
+	sort.SliceStable(words, func(i, j int) bool {
+		if words[i].y != words[j].y {
+			return words[i].y < words[j].y
+		}
+		return words[i].x < words[j].x
+	})
+
+	// Group name-column words into visual lines (~25px vertical threshold),
+	// so a multi-word name joins while a tag (which sits ~40px below the name)
+	// stays a separate line.
+	type line struct {
+		text string
+		y    int
+	}
+	var lines []line
+	for _, w := range words {
+		if w.y <= headerY+20 {
+			continue
+		}
+		if w.x < nameMinX || w.x > nameMaxX {
+			continue
+		}
+		if dateRe.MatchString(w.text) || strings.Contains(w.text, ":") {
+			continue
+		}
+		if dsIsDigits(w.text) {
+			continue // power/score value beneath the name
+		}
+		if len(lines) == 0 || w.y-lines[len(lines)-1].y > 25 {
+			lines = append(lines, line{text: w.text, y: w.y})
+			continue
+		}
+		lines[len(lines)-1].text += " " + w.text
+	}
+
+	// Each row's name is the first line after a >200px vertical gap (rows are
+	// ~382px apart; tag/power lines trail the name by <200px).
+	var names []ZSOCRRecord
+	lastY := -100000
+	for _, l := range lines {
+		if l.y-lastY <= 200 {
+			continue
+		}
+		names = append(names, ZSOCRRecord{MemberName: strings.TrimSpace(l.text)})
+		lastY = l.y
+	}
+
+	// Dedupe by name (first occurrence = higher rank).
+	seen := map[string]bool{}
+	out := names[:0]
+	for _, r := range names {
+		key := strings.ToLower(r.MemberName)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, r)
+	}
+	return out, eventDate
+}
+
+// zsParseWaves extracts wave counts from word boxes. minX filters to the right
+// column (0 for an already-cropped right-column pass, ~78% of width for a
+// full-width pass). cropHeight bounds the search so the "0" from the report
+// timestamp ("22:33:00") is never mistaken for a wave. Waves are returned in
+// top-to-bottom (rank) order.
+func zsParseWaves(boxes []gosseract.BoundingBox, minX, cropHeight int) []int64 {
+	headerY := 0
+	for _, b := range boxes {
+		lw := strings.ToLower(strings.TrimSpace(b.Word))
+		if strings.Contains(lw, "wave") && b.Box.Min.Y > headerY {
+			headerY = b.Box.Min.Y
+		}
+	}
+	maxY := cropHeight * 85 / 100
+	if maxY <= headerY {
+		maxY = cropHeight // header not found; no cap
+	}
+
+	type wave struct {
+		y int
+		n int64
+	}
+	var waves []wave
+	for _, b := range boxes {
+		if b.Box.Min.Y <= headerY+20 || b.Box.Min.Y > maxY {
+			continue
+		}
+		if b.Box.Min.X < minX {
+			continue
+		}
+		if n, ok := parseZSWave(b.Word); ok {
+			waves = append(waves, wave{y: b.Box.Min.Y, n: n})
+		}
+	}
+	sort.SliceStable(waves, func(i, j int) bool { return waves[i].y < waves[j].y })
+	out := make([]int64, len(waves))
+	for i, w := range waves {
+		out[i] = w.n
+	}
+	return out
+}
+
+// extractZombieSiegeDataFromImage OCRs a Zombie Siege report screenshot using
+// two passes: names come from a full-width 2x crop, wave counts from a
+// right-column 4x crop (the small wave text is illegible at 2x). Names and
+// waves are both rank-ordered top-to-bottom, so they are zipped by index.
+// Returns records sorted by waves descending plus the detected event date.
+func extractZombieSiegeDataFromImage(imageData []byte) ([]ZSOCRRecord, string, error) {
+	img, _, err := image.Decode(bytes.NewReader(imageData))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to decode image: %v", err)
+	}
+
+	attrs := analyzeScreenshot(img)
+	if attrs.DataRegion == nil || attrs.Width <= 0 {
+		return nil, "", fmt.Errorf("could not analyze screenshot")
+	}
+	cropTop := attrs.DataRegion.Top
+	cropBottom := attrs.DataRegion.Bottom
+	if cropBottom > attrs.Height {
+		cropBottom = attrs.Height
+	}
+	if cropTop >= cropBottom {
+		return nil, "", fmt.Errorf("invalid crop region")
+	}
+
+	// Pass 1: names from full-width 2x crop; also harvest any legible wave
+	// numbers from the right column of that same pass (some screenshots read
+	// the wave at 2x but not at 4x).
+	var names []ZSOCRRecord
+	var waves2x []int64
+	eventDate := ""
+	{
+		crop := image.NewRGBA(image.Rect(0, 0, attrs.Width, cropBottom-cropTop))
+		draw.Draw(crop, crop.Bounds(), img, image.Point{0, cropTop}, draw.Src)
+		gray := convertToGrayscale(scaleImage(crop, 2))
+		crop2xWidth := gray.Bounds().Dx()
+		crop2xHeight := gray.Bounds().Dy()
+		data, err := encodePNGBytes(gray)
+		if err != nil {
+			return nil, "", err
+		}
+		client := gosseract.NewClient()
+		if err := client.SetImageFromBytes(data); err != nil {
+			client.Close()
+			return nil, "", fmt.Errorf("failed to load image: %v", err)
+		}
+		for _, mode := range []gosseract.PageSegMode{gosseract.PSM_AUTO, gosseract.PSM_SPARSE_TEXT, gosseract.PSM_SINGLE_BLOCK} {
+			client.SetPageSegMode(mode)
+			boxes, err := client.GetBoundingBoxes(gosseract.RIL_WORD)
+			if err != nil || len(boxes) == 0 {
+				continue
+			}
+			names, eventDate = zsParseNames(boxes, crop2xWidth)
+			if len(names) > 0 {
+				waves2x = zsParseWaves(boxes, crop2xWidth*78/100, crop2xHeight)
+				break
+			}
+		}
+		client.Close()
+	}
+
+	// Pass 2: waves from right-column 4x crop (the small wave text is only
+	// legible when upscaled).
+	var waves []int64
+	{
+		cropLeft := attrs.Width * 60 / 100
+		cropRight := attrs.Width
+		crop := image.NewRGBA(image.Rect(0, 0, cropRight-cropLeft, cropBottom-cropTop))
+		draw.Draw(crop, crop.Bounds(), img, image.Point{cropLeft, cropTop}, draw.Src)
+		gray := convertToGrayscale(scaleImage(crop, 4))
+		crop4xHeight := gray.Bounds().Dy()
+		data, err := encodePNGBytes(gray)
+		if err != nil {
+			return nil, eventDate, err
+		}
+		client := gosseract.NewClient()
+		if err := client.SetImageFromBytes(data); err != nil {
+			client.Close()
+			return nil, eventDate, fmt.Errorf("failed to load image: %v", err)
+		}
+		for _, mode := range []gosseract.PageSegMode{gosseract.PSM_SPARSE_TEXT, gosseract.PSM_AUTO} {
+			client.SetPageSegMode(mode)
+			boxes, err := client.GetBoundingBoxes(gosseract.RIL_WORD)
+			if err != nil || len(boxes) == 0 {
+				continue
+			}
+			waves = zsParseWaves(boxes, 0, crop4xHeight)
+			if len(waves) > 0 {
+				break
+			}
+		}
+		client.Close()
+	}
+
+	if len(names) == 0 {
+		return nil, eventDate, fmt.Errorf("no valid records found in Zombie Siege screenshot")
+	}
+
+	// Prefer whichever wave pass recovered more rows; fall back to the other.
+	if len(waves2x) > len(waves) {
+		waves = waves2x
+	}
+
+	n := len(names)
+	if len(waves) < n {
+		n = len(waves)
+	}
+	records := names[:n]
+	for i := 0; i < n; i++ {
+		records[i].Waves = waves[i]
+	}
+
+	sort.SliceStable(records, func(i, j int) bool {
+		if records[i].Waves != records[j].Waves {
+			return records[i].Waves > records[j].Waves
+		}
+		return strings.ToLower(records[i].MemberName) < strings.ToLower(records[j].MemberName)
+	})
 	return records, eventDate, nil
 }
 
@@ -11452,6 +11817,527 @@ func processDesertStormScreenshots(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(DesertStormOCRResult{
 		EventDate:       eventDate,
 		TotalDamage:     totalDamage,
+		Participants:    allParticipants,
+		ExistingEventID: existingEventID,
+	})
+}
+
+// ============================================================
+// Zombie Siege handlers
+// ============================================================
+
+type ZombieSiegeEvent struct {
+	ID               int                      `json:"id"`
+	EventDate        string                   `json:"event_date"`
+	TotalWaves       int64                    `json:"total_waves"`
+	Notes            string                   `json:"notes"`
+	CreatedAt        string                   `json:"created_at"`
+	CreatedByID      *int                     `json:"created_by_id"`
+	ParticipantCount int                      `json:"participant_count,omitempty"`
+	TopWaveDefender  string                   `json:"top_wave_defender,omitempty"`
+	TopWaves         int64                    `json:"top_waves,omitempty"`
+	Participants     []ZombieSiegeParticipant `json:"participants,omitempty"`
+}
+
+type ZombieSiegeParticipant struct {
+	ID           int    `json:"id"`
+	EventID      int    `json:"event_id"`
+	MemberID     *int   `json:"member_id"`
+	MemberName   string `json:"member_name,omitempty"`
+	NameSnapshot string `json:"name_snapshot"`
+	AllianceTag  string `json:"alliance_tag"`
+	RankInEvent  int    `json:"rank_in_event"`
+	Waves        int64  `json:"waves"`
+}
+
+type ZombieSiegeOCRResult struct {
+	EventDate       string             `json:"event_date"`
+	TotalWaves      int64              `json:"total_waves"`
+	Participants    []ZSOCRParticipant `json:"participants"`
+	ExistingEventID *int               `json:"existing_event_id,omitempty"`
+}
+
+type ZSOCRParticipant struct {
+	RankInEvent  int    `json:"rank_in_event"`
+	NameSnapshot string `json:"name_snapshot"`
+	AllianceTag  string `json:"alliance_tag"`
+	Waves        int64  `json:"waves"`
+	MemberID     *int   `json:"member_id"`
+	MemberName   string `json:"member_name,omitempty"`
+}
+
+type ZSConfirmRequest struct {
+	EventDate        string             `json:"event_date"`
+	TotalWaves       int64              `json:"total_waves"`
+	Notes            string             `json:"notes"`
+	OverwriteEventID *int               `json:"overwrite_event_id,omitempty"`
+	Participants     []ZSOCRParticipant `json:"participants"`
+}
+
+type ZSMemberStats struct {
+	MemberID   int     `json:"member_id"`
+	MemberName string  `json:"member_name"`
+	MemberRank string  `json:"member_rank"`
+	EventCount int     `json:"event_count"`
+	TotalWaves int64   `json:"total_waves"`
+	AvgRank    float64 `json:"avg_rank"`
+	BestWaves  int64   `json:"best_waves"`
+}
+
+// matchZSParticipant links an OCR participant to a member (same strategy as
+// Marshal Guard / Desert Storm: exact name → nickname → fuzzy → OCR-normalised).
+func matchZSParticipant(p *ZSOCRParticipant, members []Member) {
+	name := strings.TrimSpace(p.NameSnapshot)
+	if name == "" {
+		return
+	}
+	lower := strings.ToLower(name)
+
+	for _, m := range members {
+		if strings.ToLower(m.Name) == lower {
+			p.MemberID = &m.ID
+			p.MemberName = m.Name
+			return
+		}
+	}
+	for _, m := range members {
+		if m.Nickname != nil && strings.ToLower(*m.Nickname) == lower {
+			p.MemberID = &m.ID
+			p.MemberName = m.Name
+			return
+		}
+	}
+	bestScore := 0
+	bestIdx := -1
+	for i, m := range members {
+		sim := calculateSimilarity(name, m.Name)
+		if m.Nickname != nil && *m.Nickname != "" {
+			if nickSim := calculateSimilarity(name, *m.Nickname); nickSim > sim {
+				sim = nickSim
+			}
+		}
+		if sim > bestScore {
+			bestScore = sim
+			bestIdx = i
+		}
+	}
+	if bestScore >= 70 && bestIdx >= 0 {
+		p.MemberID = &members[bestIdx].ID
+		p.MemberName = members[bestIdx].Name
+		return
+	}
+
+	ocrNorm := mgOcrNormForCompare(name)
+	bestScore = 0
+	bestIdx = -1
+	for i, m := range members {
+		dbNorm := mgOcrNormForCompare(m.Name)
+		sim := mgSimilarityNorm(ocrNorm, dbNorm)
+		if len(ocrNorm) > 3 {
+			if s2 := mgSimilarityNorm(ocrNorm[1:], dbNorm); s2 > sim {
+				sim = s2
+			}
+		}
+		if m.Nickname != nil && *m.Nickname != "" {
+			nickNorm := mgOcrNormForCompare(*m.Nickname)
+			if s := mgSimilarityNorm(ocrNorm, nickNorm); s > sim {
+				sim = s
+			}
+		}
+		if sim > bestScore {
+			bestScore = sim
+			bestIdx = i
+		}
+	}
+	if bestScore >= 70 && bestIdx >= 0 {
+		p.MemberID = &members[bestIdx].ID
+		p.MemberName = members[bestIdx].Name
+	}
+}
+
+// GET /api/zombie-siege — list events with summary
+func listZombieSiegeEvents(w http.ResponseWriter, r *http.Request) {
+	rows, err := db.Query(`
+		SELECT e.id, e.event_date, e.total_waves, COALESCE(e.notes, ''),
+			e.created_at, e.created_by_id,
+			COUNT(p.id) as participant_count,
+			COALESCE((SELECT p2.name_snapshot FROM zombie_siege_participants p2 WHERE p2.event_id = e.id ORDER BY p2.waves DESC LIMIT 1), '') as top_defender,
+			COALESCE((SELECT p2.waves FROM zombie_siege_participants p2 WHERE p2.event_id = e.id ORDER BY p2.waves DESC LIMIT 1), 0) as top_waves
+		FROM zombie_siege_events e
+		LEFT JOIN zombie_siege_participants p ON p.event_id = e.id
+		GROUP BY e.id
+		ORDER BY e.event_date DESC`)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	events := []ZombieSiegeEvent{}
+	for rows.Next() {
+		var ev ZombieSiegeEvent
+		var createdByID sql.NullInt64
+		if err := rows.Scan(&ev.ID, &ev.EventDate, &ev.TotalWaves, &ev.Notes,
+			&ev.CreatedAt, &createdByID, &ev.ParticipantCount, &ev.TopWaveDefender, &ev.TopWaves); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if createdByID.Valid {
+			id := int(createdByID.Int64)
+			ev.CreatedByID = &id
+		}
+		events = append(events, ev)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(events)
+}
+
+// GET /api/zombie-siege/{id} — get event with participants
+func getZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(mux.Vars(r)["id"])
+
+	var ev ZombieSiegeEvent
+	var createdByID sql.NullInt64
+	err := db.QueryRow(`SELECT id, event_date, total_waves, COALESCE(notes, ''), created_at, created_by_id
+		FROM zombie_siege_events WHERE id = ?`, id).Scan(
+		&ev.ID, &ev.EventDate, &ev.TotalWaves, &ev.Notes, &ev.CreatedAt, &createdByID)
+	if err != nil {
+		http.Error(w, "Event not found", http.StatusNotFound)
+		return
+	}
+	if createdByID.Valid {
+		cid := int(createdByID.Int64)
+		ev.CreatedByID = &cid
+	}
+
+	rows, err := db.Query(`
+		SELECT p.id, p.event_id, p.member_id, COALESCE(m.name, ''), p.name_snapshot,
+			COALESCE(p.alliance_tag, ''), p.rank_in_event, p.waves
+		FROM zombie_siege_participants p
+		LEFT JOIN members m ON m.id = p.member_id
+		WHERE p.event_id = ?
+		ORDER BY p.rank_in_event`, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	ev.Participants = []ZombieSiegeParticipant{}
+	for rows.Next() {
+		var p ZombieSiegeParticipant
+		var memberID sql.NullInt64
+		if err := rows.Scan(&p.ID, &p.EventID, &memberID, &p.MemberName,
+			&p.NameSnapshot, &p.AllianceTag, &p.RankInEvent, &p.Waves); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if memberID.Valid {
+			mid := int(memberID.Int64)
+			p.MemberID = &mid
+		}
+		ev.Participants = append(ev.Participants, p)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ev)
+}
+
+// POST /api/zombie-siege — create event manually (no OCR)
+func createZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EventDate  string `json:"event_date"`
+		TotalWaves int64  `json:"total_waves"`
+		Notes      string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.EventDate == "" {
+		http.Error(w, "event_date is required", http.StatusBadRequest)
+		return
+	}
+
+	session, _ := store.Get(r, "session")
+	userID, _ := session.Values["user_id"].(int)
+
+	result, err := db.Exec(`INSERT INTO zombie_siege_events (event_date, total_waves, notes, created_by_id)
+		VALUES (?, ?, ?, ?)`, req.EventDate, req.TotalWaves, req.Notes, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	id, _ := result.LastInsertId()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"id": id, "message": "Event created"})
+}
+
+// PUT /api/zombie-siege/{id} — update event metadata
+func updateZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(mux.Vars(r)["id"])
+	var req struct {
+		EventDate  string `json:"event_date"`
+		TotalWaves int64  `json:"total_waves"`
+		Notes      string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, err := db.Exec(`UPDATE zombie_siege_events SET event_date = ?, total_waves = ?, notes = ? WHERE id = ?`,
+		req.EventDate, req.TotalWaves, req.Notes, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "Event updated"})
+}
+
+// DELETE /api/zombie-siege/{id} — delete event + participants (cascade)
+func deleteZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(mux.Vars(r)["id"])
+	db.Exec("PRAGMA foreign_keys = ON")
+	_, err := db.Exec(`DELETE FROM zombie_siege_events WHERE id = ?`, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "Event deleted"})
+}
+
+// PUT /api/zombie-siege/{id}/participants/{pid} — fix single participant
+func updateZombieSiegeParticipant(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	pid, _ := strconv.Atoi(vars["pid"])
+	var req struct {
+		MemberID     *int   `json:"member_id"`
+		NameSnapshot string `json:"name_snapshot"`
+		Waves        int64  `json:"waves"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, err := db.Exec(`UPDATE zombie_siege_participants SET member_id = ?, name_snapshot = ?, waves = ? WHERE id = ?`,
+		req.MemberID, req.NameSnapshot, req.Waves, pid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "Participant updated"})
+}
+
+// GET /api/zombie-siege/member-stats — per-member Zombie Siege stats
+func getZombieSiegeMemberStats(w http.ResponseWriter, r *http.Request) {
+	rows, err := db.Query(`
+		SELECT p.member_id, m.name, m.rank,
+			COUNT(DISTINCT p.event_id) as event_count,
+			COALESCE(SUM(p.waves), 0) as total_waves,
+			COALESCE(AVG(p.rank_in_event), 0) as avg_rank,
+			COALESCE(MAX(p.waves), 0) as best_waves
+		FROM zombie_siege_participants p
+		JOIN members m ON m.id = p.member_id
+		WHERE p.member_id IS NOT NULL
+		GROUP BY p.member_id
+		ORDER BY total_waves DESC`)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	stats := []ZSMemberStats{}
+	for rows.Next() {
+		var s ZSMemberStats
+		if err := rows.Scan(&s.MemberID, &s.MemberName, &s.MemberRank,
+			&s.EventCount, &s.TotalWaves, &s.AvgRank, &s.BestWaves); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		stats = append(stats, s)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
+}
+
+// POST /api/zombie-siege/confirm — atomic create event + participants
+func confirmZombieSiege(w http.ResponseWriter, r *http.Request) {
+	var req ZSConfirmRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.EventDate == "" {
+		http.Error(w, "event_date is required", http.StatusBadRequest)
+		return
+	}
+
+	session, _ := store.Get(r, "session")
+	userID, _ := session.Values["user_id"].(int)
+
+	tx, err := db.Begin()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	if req.OverwriteEventID != nil {
+		tx.Exec("PRAGMA foreign_keys = ON")
+		if _, err := tx.Exec(`DELETE FROM zombie_siege_events WHERE id = ?`, *req.OverwriteEventID); err != nil {
+			http.Error(w, "Failed to overwrite existing event: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	result, err := tx.Exec(`INSERT INTO zombie_siege_events (event_date, total_waves, notes, created_by_id) VALUES (?, ?, ?, ?)`,
+		req.EventDate, req.TotalWaves, req.Notes, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	eventID, _ := result.LastInsertId()
+
+	added := 0
+	for _, p := range req.Participants {
+		_, err := tx.Exec(`INSERT INTO zombie_siege_participants (event_id, member_id, name_snapshot, alliance_tag, rank_in_event, waves)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			eventID, p.MemberID, p.NameSnapshot, p.AllianceTag, p.RankInEvent, p.Waves)
+		if err != nil {
+			log.Printf("ZS confirm: failed to insert participant rank %d: %v", p.RankInEvent, err)
+			continue
+		}
+		added++
+	}
+
+	if err := tx.Commit(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"event_id": eventID,
+		"added":    added,
+		"message":  fmt.Sprintf("Event created with %d participants", added),
+	})
+}
+
+// POST /api/zombie-siege/process-screenshots — OCR parse ZS screenshots
+func processZombieSiegeScreenshots(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "Failed to parse form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	files := r.MultipartForm.File["images[]"]
+	if len(files) == 0 {
+		files = r.MultipartForm.File["image"]
+	}
+	if len(files) == 0 {
+		http.Error(w, "No images provided", http.StatusBadRequest)
+		return
+	}
+	if len(files) > 40 {
+		http.Error(w, "Maximum 40 images allowed", http.StatusBadRequest)
+		return
+	}
+
+	var allParticipants []ZSOCRParticipant
+	var eventDate string
+
+	for _, fh := range files {
+		file, err := fh.Open()
+		if err != nil {
+			continue
+		}
+		imageData, err := io.ReadAll(file)
+		file.Close()
+		if err != nil {
+			continue
+		}
+
+		records, date, err := extractZombieSiegeDataFromImage(imageData)
+		if err != nil {
+			log.Printf("ZS OCR: %v", err)
+			continue
+		}
+		if date != "" && eventDate == "" {
+			eventDate = date
+		}
+
+		for _, rec := range records {
+			if rec.MemberName == "" {
+				continue
+			}
+			p := ZSOCRParticipant{
+				NameSnapshot: rec.MemberName,
+				AllianceTag:  rec.AllianceTag,
+				Waves:        rec.Waves,
+			}
+			merged := false
+			for i, existing := range allParticipants {
+				if strings.EqualFold(existing.NameSnapshot, p.NameSnapshot) ||
+					calculateSimilarity(existing.NameSnapshot, p.NameSnapshot) >= 75 {
+					if p.Waves > existing.Waves {
+						allParticipants[i].Waves = p.Waves
+						allParticipants[i].AllianceTag = p.AllianceTag
+					}
+					merged = true
+					break
+				}
+			}
+			if !merged {
+				allParticipants = append(allParticipants, p)
+			}
+		}
+	}
+
+	if manualDate := r.FormValue("event_date"); manualDate != "" {
+		eventDate = manualDate
+	}
+
+	// Rank by waves descending (higher waves = lower rank number).
+	sort.SliceStable(allParticipants, func(i, j int) bool {
+		if allParticipants[i].Waves != allParticipants[j].Waves {
+			return allParticipants[i].Waves > allParticipants[j].Waves
+		}
+		return strings.ToLower(allParticipants[i].NameSnapshot) < strings.ToLower(allParticipants[j].NameSnapshot)
+	})
+	var totalWaves int64
+	for i := range allParticipants {
+		allParticipants[i].RankInEvent = i + 1
+		totalWaves += allParticipants[i].Waves
+	}
+
+	members, err := loadAllMembers()
+	if err == nil {
+		for i := range allParticipants {
+			matchZSParticipant(&allParticipants[i], members)
+		}
+	}
+
+	var existingEventID *int
+	if eventDate != "" {
+		var eid int
+		err := db.QueryRow(`SELECT id FROM zombie_siege_events WHERE event_date = ?`, eventDate).Scan(&eid)
+		if err == nil {
+			existingEventID = &eid
+		}
+	}
+
+	sort.Slice(allParticipants, func(i, j int) bool {
+		return allParticipants[i].RankInEvent < allParticipants[j].RankInEvent
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ZombieSiegeOCRResult{
+		EventDate:       eventDate,
+		TotalWaves:      totalWaves,
 		Participants:    allParticipants,
 		ExistingEventID: existingEventID,
 	})
@@ -15696,6 +16582,17 @@ func main() {
 	router.HandleFunc("/api/desert-storm/{id}", authMiddleware(rankManagementMiddleware(updateDesertStormEvent))).Methods("PUT")
 	router.HandleFunc("/api/desert-storm/{id}", authMiddleware(rankManagementMiddleware(deleteDesertStormEvent))).Methods("DELETE")
 	router.HandleFunc("/api/desert-storm/{id}/participants/{pid}", authMiddleware(rankManagementMiddleware(updateDesertStormParticipant))).Methods("PUT")
+
+	// Zombie Siege routes (protected)
+	router.HandleFunc("/api/zombie-siege", authMiddleware(listZombieSiegeEvents)).Methods("GET")
+	router.HandleFunc("/api/zombie-siege", authMiddleware(r3PlusMiddleware(createZombieSiegeEvent))).Methods("POST")
+	router.HandleFunc("/api/zombie-siege/process-screenshots", authMiddleware(r3PlusMiddleware(processZombieSiegeScreenshots))).Methods("POST")
+	router.HandleFunc("/api/zombie-siege/confirm", authMiddleware(r3PlusMiddleware(confirmZombieSiege))).Methods("POST")
+	router.HandleFunc("/api/zombie-siege/member-stats", authMiddleware(getZombieSiegeMemberStats)).Methods("GET")
+	router.HandleFunc("/api/zombie-siege/{id}", authMiddleware(getZombieSiegeEvent)).Methods("GET")
+	router.HandleFunc("/api/zombie-siege/{id}", authMiddleware(rankManagementMiddleware(updateZombieSiegeEvent))).Methods("PUT")
+	router.HandleFunc("/api/zombie-siege/{id}", authMiddleware(rankManagementMiddleware(deleteZombieSiegeEvent))).Methods("DELETE")
+	router.HandleFunc("/api/zombie-siege/{id}/participants/{pid}", authMiddleware(rankManagementMiddleware(updateZombieSiegeParticipant))).Methods("PUT")
 
 	// Donations routes (protected)
 	router.HandleFunc("/api/donations", authMiddleware(getDonationRecords)).Methods("GET")

--- a/main.go
+++ b/main.go
@@ -245,6 +245,7 @@ type Settings struct {
 	MinHQLevel                   int    `json:"min_hq_level"`
 	VipSeatEnabled               bool   `json:"vip_seat_enabled"`
 	MarshalGuardEnabled          bool   `json:"marshal_guard_enabled"`
+	DesertStormEnabled           bool   `json:"desert_storm_enabled"`
 }
 
 type MemberRanking struct {
@@ -1885,6 +1886,17 @@ Ask in alliance chat for the train to be assigned. Thanks for keeping the train 
 		log.Println("Database migration: Added marshal_guard_enabled column to settings table")
 	}
 
+	// Migrate settings table to add desert_storm_enabled column if missing
+	var dsEnabledColumnExists bool
+	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('settings') WHERE name='desert_storm_enabled'`).Scan(&dsEnabledColumnExists)
+	if err != nil || !dsEnabledColumnExists {
+		_, err = db.Exec(`ALTER TABLE settings ADD COLUMN desert_storm_enabled INTEGER NOT NULL DEFAULT 1`)
+		if err != nil {
+			return err
+		}
+		log.Println("Database migration: Added desert_storm_enabled column to settings table")
+	}
+
 	// Create marshal_guard_events table
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS marshal_guard_events (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1908,6 +1920,35 @@ Ask in alliance chat for the train to be assigned. Thanks for keeping the train 
 		rank_in_event INTEGER NOT NULL,
 		damage INTEGER NOT NULL DEFAULT 0,
 		attack_count INTEGER,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(event_id, rank_in_event)
+	)`)
+	if err != nil {
+		return err
+	}
+
+	// Create desert_storm_events table (individual points ranking)
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS desert_storm_events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_date TEXT NOT NULL,
+		total_alliance_damage INTEGER NOT NULL DEFAULT 0,
+		notes TEXT,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		created_by_id INTEGER REFERENCES users(id)
+	)`)
+	if err != nil {
+		return err
+	}
+
+	// Create desert_storm_participants table
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS desert_storm_participants (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_id INTEGER NOT NULL REFERENCES desert_storm_events(id) ON DELETE CASCADE,
+		member_id INTEGER REFERENCES members(id),
+		name_snapshot TEXT NOT NULL,
+		alliance_tag TEXT,
+		rank_in_event INTEGER NOT NULL,
+		damage INTEGER NOT NULL DEFAULT 0,
 		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 		UNIQUE(event_id, rank_in_event)
 	)`)
@@ -4776,7 +4817,8 @@ func getSettings(w http.ResponseWriter, r *http.Request) {
 		COALESCE(min_power, 0) as min_power,
 		COALESCE(min_hq_level, 0) as min_hq_level,
 		COALESCE(vip_seat_enabled, 1) as vip_seat_enabled,
-		COALESCE(marshal_guard_enabled, 1) as marshal_guard_enabled
+		COALESCE(marshal_guard_enabled, 1) as marshal_guard_enabled,
+		COALESCE(desert_storm_enabled, 1) as desert_storm_enabled
 		FROM settings WHERE id = 1`).Scan(
 		&settings.ID,
 		&settings.AllianceName,
@@ -4802,6 +4844,7 @@ func getSettings(w http.ResponseWriter, r *http.Request) {
 		&settings.MinHQLevel,
 		&settings.VipSeatEnabled,
 		&settings.MarshalGuardEnabled,
+		&settings.DesertStormEnabled,
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -4853,7 +4896,8 @@ func updateSettings(w http.ResponseWriter, r *http.Request) {
 		min_power = ?,
 		min_hq_level = ?,
 		vip_seat_enabled = ?,
-		marshal_guard_enabled = ?
+		marshal_guard_enabled = ?,
+		desert_storm_enabled = ?
 		WHERE id = 1`,
 		settings.AllianceName,
 		settings.AllianceShortName,
@@ -4878,6 +4922,7 @@ func updateSettings(w http.ResponseWriter, r *http.Request) {
 		settings.MinHQLevel,
 		settings.VipSeatEnabled,
 		settings.MarshalGuardEnabled,
+		settings.DesertStormEnabled,
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -10888,6 +10933,531 @@ func processPowerScreenshot(w http.ResponseWriter, r *http.Request) {
 }
 
 // ============================================================
+// Desert Storm handlers
+// ============================================================
+
+type DesertStormEvent struct {
+	ID                  int                      `json:"id"`
+	EventDate           string                   `json:"event_date"`
+	TotalAllianceDamage int64                    `json:"total_alliance_damage"`
+	Notes               string                   `json:"notes"`
+	CreatedAt           string                   `json:"created_at"`
+	CreatedByID         *int                     `json:"created_by_id"`
+	ParticipantCount    int                      `json:"participant_count,omitempty"`
+	TopDamageDealer     string                   `json:"top_damage_dealer,omitempty"`
+	TopDamage           int64                    `json:"top_damage,omitempty"`
+	Participants        []DesertStormParticipant `json:"participants,omitempty"`
+}
+
+type DesertStormParticipant struct {
+	ID           int    `json:"id"`
+	EventID      int    `json:"event_id"`
+	MemberID     *int   `json:"member_id"`
+	MemberName   string `json:"member_name,omitempty"`
+	NameSnapshot string `json:"name_snapshot"`
+	AllianceTag  string `json:"alliance_tag"`
+	RankInEvent  int    `json:"rank_in_event"`
+	Damage       int64  `json:"damage"`
+}
+
+type DesertStormOCRResult struct {
+	EventDate       string             `json:"event_date"`
+	TotalDamage     int64              `json:"total_damage"`
+	Participants    []DSOCRParticipant `json:"participants"`
+	ExistingEventID *int               `json:"existing_event_id,omitempty"`
+}
+
+type DSOCRParticipant struct {
+	RankInEvent  int    `json:"rank_in_event"`
+	NameSnapshot string `json:"name_snapshot"`
+	AllianceTag  string `json:"alliance_tag"`
+	Damage       int64  `json:"damage"`
+	MemberID     *int   `json:"member_id"`
+	MemberName   string `json:"member_name,omitempty"`
+}
+
+type DSConfirmRequest struct {
+	EventDate        string             `json:"event_date"`
+	TotalDamage      int64              `json:"total_damage"`
+	Notes            string             `json:"notes"`
+	OverwriteEventID *int               `json:"overwrite_event_id,omitempty"`
+	Participants     []DSOCRParticipant `json:"participants"`
+}
+
+type DSMemberStats struct {
+	MemberID    int     `json:"member_id"`
+	MemberName  string  `json:"member_name"`
+	MemberRank  string  `json:"member_rank"`
+	EventCount  int     `json:"event_count"`
+	TotalDamage int64   `json:"total_damage"`
+	AvgRank     float64 `json:"avg_rank"`
+	BestDamage  int64   `json:"best_damage"`
+}
+
+// matchDSParticipant links an OCR participant to a member using the same
+// matching strategy as Marshal Guard (exact name → nickname → fuzzy →
+// OCR-normalised).
+func matchDSParticipant(p *DSOCRParticipant, members []Member) {
+	name := strings.TrimSpace(p.NameSnapshot)
+	if name == "" {
+		return
+	}
+	lower := strings.ToLower(name)
+
+	for _, m := range members {
+		if strings.ToLower(m.Name) == lower {
+			p.MemberID = &m.ID
+			p.MemberName = m.Name
+			return
+		}
+	}
+	for _, m := range members {
+		if m.Nickname != nil && strings.ToLower(*m.Nickname) == lower {
+			p.MemberID = &m.ID
+			p.MemberName = m.Name
+			return
+		}
+	}
+	bestScore := 0
+	bestIdx := -1
+	for i, m := range members {
+		sim := calculateSimilarity(name, m.Name)
+		if m.Nickname != nil && *m.Nickname != "" {
+			if nickSim := calculateSimilarity(name, *m.Nickname); nickSim > sim {
+				sim = nickSim
+			}
+		}
+		if sim > bestScore {
+			bestScore = sim
+			bestIdx = i
+		}
+	}
+	if bestScore >= 70 && bestIdx >= 0 {
+		p.MemberID = &members[bestIdx].ID
+		p.MemberName = members[bestIdx].Name
+		return
+	}
+
+	ocrNorm := mgOcrNormForCompare(name)
+	bestScore = 0
+	bestIdx = -1
+	for i, m := range members {
+		dbNorm := mgOcrNormForCompare(m.Name)
+		sim := mgSimilarityNorm(ocrNorm, dbNorm)
+		if len(ocrNorm) > 3 {
+			if s2 := mgSimilarityNorm(ocrNorm[1:], dbNorm); s2 > sim {
+				sim = s2
+			}
+		}
+		if m.Nickname != nil && *m.Nickname != "" {
+			nickNorm := mgOcrNormForCompare(*m.Nickname)
+			if s := mgSimilarityNorm(ocrNorm, nickNorm); s > sim {
+				sim = s
+			}
+		}
+		if sim > bestScore {
+			bestScore = sim
+			bestIdx = i
+		}
+	}
+	if bestScore >= 70 && bestIdx >= 0 {
+		p.MemberID = &members[bestIdx].ID
+		p.MemberName = members[bestIdx].Name
+	}
+}
+
+// GET /api/desert-storm — list events with summary
+func listDesertStormEvents(w http.ResponseWriter, r *http.Request) {
+	rows, err := db.Query(`
+		SELECT e.id, e.event_date, e.total_alliance_damage, COALESCE(e.notes, ''),
+			e.created_at, e.created_by_id,
+			COUNT(p.id) as participant_count,
+			COALESCE((SELECT p2.name_snapshot FROM desert_storm_participants p2 WHERE p2.event_id = e.id ORDER BY p2.damage DESC LIMIT 1), '') as top_dealer,
+			COALESCE((SELECT p2.damage FROM desert_storm_participants p2 WHERE p2.event_id = e.id ORDER BY p2.damage DESC LIMIT 1), 0) as top_damage
+		FROM desert_storm_events e
+		LEFT JOIN desert_storm_participants p ON p.event_id = e.id
+		GROUP BY e.id
+		ORDER BY e.event_date DESC`)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	events := []DesertStormEvent{}
+	for rows.Next() {
+		var ev DesertStormEvent
+		var createdByID sql.NullInt64
+		if err := rows.Scan(&ev.ID, &ev.EventDate, &ev.TotalAllianceDamage, &ev.Notes,
+			&ev.CreatedAt, &createdByID, &ev.ParticipantCount, &ev.TopDamageDealer, &ev.TopDamage); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if createdByID.Valid {
+			id := int(createdByID.Int64)
+			ev.CreatedByID = &id
+		}
+		events = append(events, ev)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(events)
+}
+
+// GET /api/desert-storm/{id} — get event with participants
+func getDesertStormEvent(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(mux.Vars(r)["id"])
+
+	var ev DesertStormEvent
+	var createdByID sql.NullInt64
+	err := db.QueryRow(`SELECT id, event_date, total_alliance_damage, COALESCE(notes, ''), created_at, created_by_id
+		FROM desert_storm_events WHERE id = ?`, id).Scan(
+		&ev.ID, &ev.EventDate, &ev.TotalAllianceDamage, &ev.Notes, &ev.CreatedAt, &createdByID)
+	if err != nil {
+		http.Error(w, "Event not found", http.StatusNotFound)
+		return
+	}
+	if createdByID.Valid {
+		cid := int(createdByID.Int64)
+		ev.CreatedByID = &cid
+	}
+
+	rows, err := db.Query(`
+		SELECT p.id, p.event_id, p.member_id, COALESCE(m.name, ''), p.name_snapshot,
+			COALESCE(p.alliance_tag, ''), p.rank_in_event, p.damage
+		FROM desert_storm_participants p
+		LEFT JOIN members m ON m.id = p.member_id
+		WHERE p.event_id = ?
+		ORDER BY p.rank_in_event`, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	ev.Participants = []DesertStormParticipant{}
+	for rows.Next() {
+		var p DesertStormParticipant
+		var memberID sql.NullInt64
+		if err := rows.Scan(&p.ID, &p.EventID, &memberID, &p.MemberName,
+			&p.NameSnapshot, &p.AllianceTag, &p.RankInEvent, &p.Damage); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if memberID.Valid {
+			mid := int(memberID.Int64)
+			p.MemberID = &mid
+		}
+		ev.Participants = append(ev.Participants, p)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ev)
+}
+
+// POST /api/desert-storm — create event manually (no OCR)
+func createDesertStormEvent(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EventDate           string `json:"event_date"`
+		TotalAllianceDamage int64  `json:"total_alliance_damage"`
+		Notes               string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.EventDate == "" {
+		http.Error(w, "event_date is required", http.StatusBadRequest)
+		return
+	}
+
+	session, _ := store.Get(r, "session")
+	userID, _ := session.Values["user_id"].(int)
+
+	result, err := db.Exec(`INSERT INTO desert_storm_events (event_date, total_alliance_damage, notes, created_by_id)
+		VALUES (?, ?, ?, ?)`, req.EventDate, req.TotalAllianceDamage, req.Notes, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	id, _ := result.LastInsertId()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"id": id, "message": "Event created"})
+}
+
+// PUT /api/desert-storm/{id} — update event metadata
+func updateDesertStormEvent(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(mux.Vars(r)["id"])
+	var req struct {
+		EventDate           string `json:"event_date"`
+		TotalAllianceDamage int64  `json:"total_alliance_damage"`
+		Notes               string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, err := db.Exec(`UPDATE desert_storm_events SET event_date = ?, total_alliance_damage = ?, notes = ? WHERE id = ?`,
+		req.EventDate, req.TotalAllianceDamage, req.Notes, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "Event updated"})
+}
+
+// DELETE /api/desert-storm/{id} — delete event + participants (cascade)
+func deleteDesertStormEvent(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(mux.Vars(r)["id"])
+	db.Exec("PRAGMA foreign_keys = ON")
+	_, err := db.Exec(`DELETE FROM desert_storm_events WHERE id = ?`, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "Event deleted"})
+}
+
+// PUT /api/desert-storm/{id}/participants/{pid} — fix single participant
+func updateDesertStormParticipant(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	pid, _ := strconv.Atoi(vars["pid"])
+	var req struct {
+		MemberID     *int   `json:"member_id"`
+		NameSnapshot string `json:"name_snapshot"`
+		Damage       int64  `json:"damage"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, err := db.Exec(`UPDATE desert_storm_participants SET member_id = ?, name_snapshot = ?, damage = ? WHERE id = ?`,
+		req.MemberID, req.NameSnapshot, req.Damage, pid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"message": "Participant updated"})
+}
+
+// GET /api/desert-storm/member-stats — per-member Desert Storm stats
+func getDesertStormMemberStats(w http.ResponseWriter, r *http.Request) {
+	rows, err := db.Query(`
+		SELECT p.member_id, m.name, m.rank,
+			COUNT(DISTINCT p.event_id) as event_count,
+			COALESCE(SUM(p.damage), 0) as total_damage,
+			COALESCE(AVG(p.rank_in_event), 0) as avg_rank,
+			COALESCE(MAX(p.damage), 0) as best_damage
+		FROM desert_storm_participants p
+		JOIN members m ON m.id = p.member_id
+		WHERE p.member_id IS NOT NULL
+		GROUP BY p.member_id
+		ORDER BY total_damage DESC`)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	stats := []DSMemberStats{}
+	for rows.Next() {
+		var s DSMemberStats
+		if err := rows.Scan(&s.MemberID, &s.MemberName, &s.MemberRank,
+			&s.EventCount, &s.TotalDamage, &s.AvgRank, &s.BestDamage); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		stats = append(stats, s)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
+}
+
+// POST /api/desert-storm/confirm — atomic create event + participants
+func confirmDesertStorm(w http.ResponseWriter, r *http.Request) {
+	var req DSConfirmRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.EventDate == "" {
+		http.Error(w, "event_date is required", http.StatusBadRequest)
+		return
+	}
+
+	session, _ := store.Get(r, "session")
+	userID, _ := session.Values["user_id"].(int)
+
+	tx, err := db.Begin()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	if req.OverwriteEventID != nil {
+		tx.Exec("PRAGMA foreign_keys = ON")
+		if _, err := tx.Exec(`DELETE FROM desert_storm_events WHERE id = ?`, *req.OverwriteEventID); err != nil {
+			http.Error(w, "Failed to overwrite existing event: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	result, err := tx.Exec(`INSERT INTO desert_storm_events (event_date, total_alliance_damage, notes, created_by_id) VALUES (?, ?, ?, ?)`,
+		req.EventDate, req.TotalDamage, req.Notes, userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	eventID, _ := result.LastInsertId()
+
+	added := 0
+	for _, p := range req.Participants {
+		_, err := tx.Exec(`INSERT INTO desert_storm_participants (event_id, member_id, name_snapshot, alliance_tag, rank_in_event, damage)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			eventID, p.MemberID, p.NameSnapshot, p.AllianceTag, p.RankInEvent, p.Damage)
+		if err != nil {
+			log.Printf("DS confirm: failed to insert participant rank %d: %v", p.RankInEvent, err)
+			continue
+		}
+		added++
+	}
+
+	if err := tx.Commit(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"event_id": eventID,
+		"added":    added,
+		"message":  fmt.Sprintf("Event created with %d participants", added),
+	})
+}
+
+// POST /api/desert-storm/process-screenshots — OCR parse DS screenshots
+func processDesertStormScreenshots(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "Failed to parse form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	files := r.MultipartForm.File["images[]"]
+	if len(files) == 0 {
+		files = r.MultipartForm.File["image"]
+	}
+	if len(files) == 0 {
+		http.Error(w, "No images provided", http.StatusBadRequest)
+		return
+	}
+	if len(files) > 40 {
+		http.Error(w, "Maximum 40 images allowed", http.StatusBadRequest)
+		return
+	}
+
+	var allParticipants []DSOCRParticipant
+	var eventDate string
+
+	for _, fh := range files {
+		file, err := fh.Open()
+		if err != nil {
+			continue
+		}
+		imageData, err := io.ReadAll(file)
+		file.Close()
+		if err != nil {
+			continue
+		}
+
+		records, date, err := extractDesertStormDataFromImage(imageData)
+		if err != nil {
+			log.Printf("DS OCR: %v", err)
+			continue
+		}
+		if date != "" && eventDate == "" {
+			eventDate = date
+		}
+
+		for _, rec := range records {
+			if rec.MemberName == "" {
+				continue
+			}
+			p := DSOCRParticipant{
+				NameSnapshot: rec.MemberName,
+				AllianceTag:  rec.AllianceTag,
+				Damage:       rec.Damage,
+			}
+			merged := false
+			for i, existing := range allParticipants {
+				if strings.EqualFold(existing.NameSnapshot, p.NameSnapshot) ||
+					calculateSimilarity(existing.NameSnapshot, p.NameSnapshot) >= 75 {
+					if p.Damage > existing.Damage {
+						allParticipants[i].Damage = p.Damage
+						allParticipants[i].AllianceTag = p.AllianceTag
+					}
+					merged = true
+					break
+				}
+			}
+			if !merged {
+				allParticipants = append(allParticipants, p)
+			}
+		}
+	}
+
+	// Manual event_date override.
+	if manualDate := r.FormValue("event_date"); manualDate != "" {
+		eventDate = manualDate
+	}
+
+	// Rank by damage descending (higher damage = lower rank number).
+	sort.SliceStable(allParticipants, func(i, j int) bool {
+		if allParticipants[i].Damage != allParticipants[j].Damage {
+			return allParticipants[i].Damage > allParticipants[j].Damage
+		}
+		return strings.ToLower(allParticipants[i].NameSnapshot) < strings.ToLower(allParticipants[j].NameSnapshot)
+	})
+	var totalDamage int64
+	for i := range allParticipants {
+		allParticipants[i].RankInEvent = i + 1
+		totalDamage += allParticipants[i].Damage
+	}
+
+	// Match participants to members.
+	members, err := loadAllMembers()
+	if err == nil {
+		for i := range allParticipants {
+			matchDSParticipant(&allParticipants[i], members)
+		}
+	}
+
+	// Check for existing event on same date.
+	var existingEventID *int
+	if eventDate != "" {
+		var eid int
+		err := db.QueryRow(`SELECT id FROM desert_storm_events WHERE event_date = ?`, eventDate).Scan(&eid)
+		if err == nil {
+			existingEventID = &eid
+		}
+	}
+
+	sort.Slice(allParticipants, func(i, j int) bool {
+		return allParticipants[i].RankInEvent < allParticipants[j].RankInEvent
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(DesertStormOCRResult{
+		EventDate:       eventDate,
+		TotalDamage:     totalDamage,
+		Participants:    allParticipants,
+		ExistingEventID: existingEventID,
+	})
+}
+
+// ============================================================
 // Marshal Guard handlers
 // ============================================================
 
@@ -15115,6 +15685,17 @@ func main() {
 	router.HandleFunc("/api/marshal-guard/{id}", authMiddleware(rankManagementMiddleware(updateMarshalGuardEvent))).Methods("PUT")
 	router.HandleFunc("/api/marshal-guard/{id}", authMiddleware(rankManagementMiddleware(deleteMarshalGuardEvent))).Methods("DELETE")
 	router.HandleFunc("/api/marshal-guard/{id}/participants/{pid}", authMiddleware(rankManagementMiddleware(updateMarshalGuardParticipant))).Methods("PUT")
+
+	// Desert Storm routes (protected)
+	router.HandleFunc("/api/desert-storm", authMiddleware(listDesertStormEvents)).Methods("GET")
+	router.HandleFunc("/api/desert-storm", authMiddleware(r3PlusMiddleware(createDesertStormEvent))).Methods("POST")
+	router.HandleFunc("/api/desert-storm/process-screenshots", authMiddleware(r3PlusMiddleware(processDesertStormScreenshots))).Methods("POST")
+	router.HandleFunc("/api/desert-storm/confirm", authMiddleware(r3PlusMiddleware(confirmDesertStorm))).Methods("POST")
+	router.HandleFunc("/api/desert-storm/member-stats", authMiddleware(getDesertStormMemberStats)).Methods("GET")
+	router.HandleFunc("/api/desert-storm/{id}", authMiddleware(getDesertStormEvent)).Methods("GET")
+	router.HandleFunc("/api/desert-storm/{id}", authMiddleware(rankManagementMiddleware(updateDesertStormEvent))).Methods("PUT")
+	router.HandleFunc("/api/desert-storm/{id}", authMiddleware(rankManagementMiddleware(deleteDesertStormEvent))).Methods("DELETE")
+	router.HandleFunc("/api/desert-storm/{id}/participants/{pid}", authMiddleware(rankManagementMiddleware(updateDesertStormParticipant))).Methods("PUT")
 
 	// Donations routes (protected)
 	router.HandleFunc("/api/donations", authMiddleware(getDonationRecords)).Methods("GET")

--- a/static/desert-storm.html
+++ b/static/desert-storm.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Desert Storm - Last War Alliance</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="branding.js"></script>
+    <script src="toast.js"></script>
+    <script src="common.js"></script>
+    <script src="navigation.js"></script>
+</head>
+<body data-h1="🏜️ Last War: Survival" data-subtitle="Desert Storm individual point rankings. Someone has to keep score.">
+    <div class="container">
+
+        <main>
+            <!-- Tab Buttons -->
+            <div class="tab-buttons">
+                <button class="tab-btn active" data-tab="events">🗓️ Events</button>
+                <button class="tab-btn" data-tab="stats">📊 Member Stats</button>
+            </div>
+
+            <!-- Events Tab -->
+            <div id="tab-events" class="tab-content active">
+                <section class="form-section">
+                    <div class="mg-toolbar">
+                        <h3>🏜️ Desert Storm Events</h3>
+                        <button id="add-event-btn" class="primary-btn uploader-only" style="display:none;">➕ Add Event</button>
+                    </div>
+                    <div id="event-list" class="rk-table-wrapper">
+                        <p class="loading">⏳ Loading events...</p>
+                    </div>
+                </section>
+            </div>
+
+            <!-- Member Stats Tab -->
+            <div id="tab-stats" class="tab-content">
+                <section class="form-section">
+                    <div class="mg-toolbar">
+                        <h3>📊 Member Statistics</h3>
+                        <input type="text" id="stats-search" class="form-control mg-search" placeholder="🔍 Search member...">
+                    </div>
+                    <div id="stats-list" class="rk-table-wrapper">
+                        <p class="loading">⏳ Loading stats...</p>
+                    </div>
+                </section>
+            </div>
+        </main>
+
+    </div>
+
+    <!-- Add Event Modal -->
+    <div id="event-modal" class="modal" style="display:none;">
+        <div class="modal-content">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3 id="event-modal-title">Add Event</h3>
+            <form id="event-form">
+
+                <div class="tab-buttons">
+                    <button type="button" class="tab-btn active" data-modal-tab="upload">📷 Screenshot Upload</button>
+                    <button type="button" class="tab-btn" data-modal-tab="manual">✍️ Manual Entry</button>
+                </div>
+
+                <!-- Upload sub-tab -->
+                <div id="modal-tab-upload" class="modal-tab-content active">
+                    <input type="file" id="ds-image-input" accept="image/*" multiple style="display:none;">
+                    <div id="ds-drop-zone" class="drop-zone">
+                        <div id="ds-drop-content">
+                            <div class="drop-icon">📁</div>
+                            <p class="drop-text">Tap to upload or drag &amp; drop</p>
+                            <p class="drop-subtext">Desert Storm ranking screenshots (up to 40 images)</p>
+                        </div>
+                        <div id="ds-preview-container" class="preview-container">
+                            <div class="preview-header">
+                                <p id="ds-files-count"></p>
+                                <button type="button" id="ds-clear-btn" class="btn btn-secondary">🗑️ Clear</button>
+                            </div>
+                            <div id="ds-preview-gallery"></div>
+                        </div>
+                    </div>
+                    <button type="button" id="ds-process-btn" class="btn btn-primary" style="display:none;">🔍 Process Screenshots with OCR</button>
+                    <div id="ds-progress-wrap" style="display:none;margin-top:.75rem;">
+                        <div style="display:flex;justify-content:space-between;font-size:.82em;margin-bottom:.3rem;">
+                            <span id="ds-progress-label">Processing…</span>
+                            <span id="ds-progress-time">0s</span>
+                        </div>
+                        <div style="background:var(--bg-secondary,#e5e7eb);border-radius:999px;height:8px;overflow:hidden;">
+                            <div id="ds-progress-bar" style="height:100%;width:0%;background:var(--primary,#6366f1);border-radius:999px;transition:width .3s ease;"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Manual sub-tab -->
+                <div id="modal-tab-manual" class="modal-tab-content">
+                    <div class="form-group">
+                        <label for="ds-date">Event Date</label>
+                        <input type="date" id="ds-date" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="ds-total-damage">Total Alliance Points</label>
+                        <input type="number" id="ds-total-damage" min="0" placeholder="e.g. 50000000">
+                    </div>
+                    <div class="form-group">
+                        <label for="ds-notes">Notes (optional)</label>
+                        <textarea id="ds-notes" rows="2" placeholder="Any notes about this event..."></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary">💾 Save Event</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- OCR Preview Modal (single event, per-row editing) -->
+    <div id="ds-ocr-modal" class="modal" style="display:none;">
+        <div class="modal-content" style="max-width:800px;">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3>📋 OCR Preview — Review &amp; Import</h3>
+            <p class="text-muted" style="margin-top:0;font-size:0.9em;">
+                Edit any cell before importing. Unmatched players need a member selected.
+            </p>
+            <div id="ds-ocr-event"></div>
+            <div class="modal-footer" style="margin-top:1rem;">
+                <button type="button" id="ds-ocr-cancel-btn" class="secondary-btn">Cancel</button>
+                <button type="button" id="ds-ocr-import-btn" class="primary-btn">✔ Import Event</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Event Detail Modal -->
+    <div id="detail-modal" class="modal" style="display:none;">
+        <div class="modal-content" style="max-width:700px;">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3 id="detail-modal-title">Event Details</h3>
+            <div id="detail-summary"></div>
+            <div id="detail-participants" class="rk-table-wrapper"></div>
+        </div>
+    </div>
+
+    <script src="theme.js"></script>
+    <script src="desert-storm.js"></script>
+</body>
+</html>

--- a/static/desert-storm.js
+++ b/static/desert-storm.js
@@ -1,0 +1,581 @@
+// Desert Storm page logic
+let canUpload = false; // R3, R4, R5, admin — can upload screenshots & import events
+let isOfficer = false; // R4, R5, admin — can edit/delete events
+let isAdmin = false;
+let selectedFiles = [];
+let ocrResult = null; // single DesertStormOCRResult preview
+let dsAllMembers = [];
+
+async function checkAuth() {
+    try {
+        const res = await fetch('/api/check-auth');
+        const data = await res.json();
+        if (!data.authenticated) { window.location.href = '/login.html'; return false; }
+        if (data.must_change_password) { window.location.href = '/profile.html?must_change_password=1'; return false; }
+
+        let display = `👤 ${data.username}`;
+        if (data.rank) display += ` (${data.rank})`;
+        const usernameDisplay = document.getElementById('username-display');
+        if (usernameDisplay) {
+            usernameDisplay.textContent = display;
+            usernameDisplay.addEventListener('click', toggleUserDropdown);
+        }
+
+        const logoutBtn = document.getElementById('dropdown-logout-btn');
+        if (logoutBtn) logoutBtn.addEventListener('click', handleLogout);
+
+        document.addEventListener('click', (event) => {
+            const dropdown = document.getElementById('user-dropdown-menu');
+            const btn = document.getElementById('username-display');
+            if (dropdown && btn && !btn.contains(event.target) && !dropdown.contains(event.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
+
+        isAdmin = data.is_admin || false;
+        const rank = (data.rank || '').toUpperCase();
+        canUpload = isAdmin || rank === 'R3' || rank === 'R4' || rank === 'R5';
+        isOfficer = isAdmin || rank === 'R4' || rank === 'R5';
+
+        if (canUpload) {
+            document.querySelectorAll('.uploader-only').forEach(el => el.style.display = '');
+        }
+        if (isOfficer) {
+            document.querySelectorAll('.officer-only').forEach(el => el.style.display = '');
+        }
+        if (isAdmin) {
+            const adminLink = document.getElementById('admin-nav-link');
+            const gyLink = document.getElementById('graveyard-nav-link');
+            if (adminLink) adminLink.style.display = 'block';
+            if (gyLink) gyLink.style.display = 'block';
+        }
+        return true;
+    } catch { return false; }
+}
+
+// ---- Tab switching ----
+function initTabs() {
+    document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.tab-btn[data-tab]').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+            btn.classList.add('active');
+            document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+        });
+    });
+    // Modal sub-tabs
+    document.querySelectorAll('[data-modal-tab]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('[data-modal-tab]').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.modal-tab-content').forEach(c => c.classList.remove('active'));
+            btn.classList.add('active');
+            document.getElementById('modal-tab-' + btn.dataset.modalTab).classList.add('active');
+        });
+    });
+}
+
+// ---- Event list ----
+async function loadEvents() {
+    try {
+        const res = await fetch('/api/desert-storm');
+        const events = await res.json();
+        renderEventList(events);
+    } catch (e) {
+        document.getElementById('event-list').innerHTML = '<p class="empty">⚠️ Failed to load events.</p>';
+    }
+}
+
+function renderEventList(events) {
+    const el = document.getElementById('event-list');
+    if (!events || events.length === 0) {
+        el.innerHTML = '<p class="empty">🏜️ No Desert Storm events recorded yet.</p>';
+        return;
+    }
+    let html = `<table class="rk-table"><thead><tr>
+        <th>Date</th><th>Total Points</th><th># Players</th><th>Top Scorer</th><th>Top Points</th>`;
+    if (isOfficer) html += '<th>Actions</th>';
+    html += '</tr></thead><tbody>';
+    for (const ev of events) {
+        html += `<tr class="mg-event-row" data-id="${ev.id}">
+            <td>${ev.event_date}</td>
+            <td>${formatPoints(ev.total_alliance_damage)}</td>
+            <td>${ev.participant_count}</td>
+            <td>${escapeHtml(ev.top_damage_dealer)}</td>
+            <td>${formatPoints(ev.top_damage)}</td>`;
+        if (isOfficer) {
+            html += `<td class="list-actions">
+                <button class="edit-schedule-btn" onclick="event.stopPropagation(); deleteEvent(${ev.id})" title="Delete">🗑️</button>
+            </td>`;
+        }
+        html += '</tr>';
+    }
+    html += '</tbody></table>';
+    el.innerHTML = html;
+
+    el.querySelectorAll('.mg-event-row').forEach(row => {
+        row.style.cursor = 'pointer';
+        row.addEventListener('click', () => viewEventDetail(parseInt(row.dataset.id)));
+    });
+}
+
+async function viewEventDetail(id) {
+    try {
+        const res = await fetch('/api/desert-storm/' + id);
+        const ev = await res.json();
+        document.getElementById('detail-modal-title').textContent = `🏜️ Event: ${ev.event_date}`;
+        document.getElementById('detail-summary').innerHTML = `
+            <p><strong>Total Alliance Points:</strong> ${formatPoints(ev.total_alliance_damage)}</p>
+            ${ev.notes ? '<p><strong>Notes:</strong> ' + escapeHtml(ev.notes) + '</p>' : ''}
+            <p><strong>Participants:</strong> ${ev.participants.length}</p>`;
+        let thtml = `<table class="rk-table"><thead><tr>
+            <th>#</th><th>Player</th><th>Points</th><th>Member</th>
+        </tr></thead><tbody>`;
+        for (const p of ev.participants) {
+            const matched = p.member_id ? `✅ ${escapeHtml(p.member_name)}` : '❌ Unmatched';
+            thtml += `<tr${p.rank_in_event === 1 ? ' class="mg-mvp-row"' : ''}>
+                <td>${p.rank_in_event === 1 ? '🏆' : p.rank_in_event}</td>
+                <td>${escapeHtml(p.name_snapshot)}${p.alliance_tag ? ' <span class="text-muted">[' + escapeHtml(p.alliance_tag) + ']</span>' : ''}</td>
+                <td>${formatPoints(p.damage)}</td>
+                <td>${matched}</td>
+            </tr>`;
+        }
+        thtml += '</tbody></table>';
+        document.getElementById('detail-participants').innerHTML = thtml;
+        document.getElementById('detail-modal').style.display = 'flex';
+    } catch (e) {
+        showToast('Failed to load event details', 'error');
+    }
+}
+
+async function deleteEvent(id) {
+    if (!confirm('Delete this Desert Storm event and all its participants?')) return;
+    try {
+        const res = await fetch('/api/desert-storm/' + id, { method: 'DELETE' });
+        if (res.ok) {
+            showToast('Event deleted', 'success');
+            loadEvents();
+        } else {
+            showToast('Failed to delete event', 'error');
+        }
+    } catch { showToast('Failed to delete event', 'error'); }
+}
+
+// ---- Member stats ----
+async function loadMemberStats() {
+    try {
+        const res = await fetch('/api/desert-storm/member-stats');
+        const stats = await res.json();
+        renderMemberStats(stats);
+    } catch {
+        document.getElementById('stats-list').innerHTML = '<p class="empty">⚠️ Failed to load stats.</p>';
+    }
+}
+
+function renderMemberStats(stats) {
+    const el = document.getElementById('stats-list');
+    if (!stats || stats.length === 0) {
+        el.innerHTML = '<p class="empty">🏜️ No participation data yet.</p>';
+        return;
+    }
+    let html = `<table class="rk-table" id="ds-stats-table"><thead><tr>
+        <th>Member</th><th>Rank</th><th>Events</th><th>Total Points</th><th>Avg Rank</th><th>Best Points</th>
+    </tr></thead><tbody>`;
+    for (const s of stats) {
+        html += `<tr>
+            <td>${escapeHtml(s.member_name)}</td>
+            <td>${escapeHtml(s.member_rank)}</td>
+            <td>${s.event_count}</td>
+            <td>${formatPoints(s.total_damage)}</td>
+            <td>${s.avg_rank.toFixed(1)}</td>
+            <td>${formatPoints(s.best_damage)}</td>
+        </tr>`;
+    }
+    html += '</tbody></table>';
+    el.innerHTML = html;
+}
+
+// ---- Upload / OCR flow ----
+function initUpload() {
+    const dropZone = document.getElementById('ds-drop-zone');
+    const fileInput = document.getElementById('ds-image-input');
+    const processBtn = document.getElementById('ds-process-btn');
+    const clearBtn = document.getElementById('ds-clear-btn');
+
+    dropZone.addEventListener('click', (e) => {
+        if (e.target.closest('button')) return;
+        fileInput.click();
+    });
+    dropZone.addEventListener('dragover', (e) => { e.preventDefault(); dropZone.classList.add('dragover'); });
+    dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+    dropZone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        dropZone.classList.remove('dragover');
+        handleFiles(e.dataTransfer.files);
+    });
+    fileInput.addEventListener('change', () => handleFiles(fileInput.files));
+    clearBtn.addEventListener('click', clearFiles);
+    processBtn.addEventListener('click', processScreenshots);
+}
+
+function handleFiles(fileList) {
+    const files = Array.from(fileList).filter(f => f.type.startsWith('image/'));
+    if (files.length === 0) return;
+    selectedFiles = selectedFiles.concat(files).slice(0, 40);
+    renderFilePreview();
+}
+
+function renderFilePreview() {
+    const gallery = document.getElementById('ds-preview-gallery');
+    const container = document.getElementById('ds-preview-container');
+    const dropContent = document.getElementById('ds-drop-content');
+    const processBtn = document.getElementById('ds-process-btn');
+    const countEl = document.getElementById('ds-files-count');
+
+    if (selectedFiles.length === 0) {
+        container.style.display = 'none';
+        dropContent.style.display = '';
+        processBtn.style.display = 'none';
+        return;
+    }
+
+    dropContent.style.display = 'none';
+    container.style.display = 'block';
+    processBtn.style.display = 'block';
+    countEl.textContent = `${selectedFiles.length} file${selectedFiles.length > 1 ? 's' : ''} selected`;
+
+    gallery.innerHTML = '';
+    selectedFiles.forEach((file, i) => {
+        const div = document.createElement('div');
+        div.className = 'preview-item';
+        const img = document.createElement('img');
+        img.className = 'preview-img';
+        img.src = URL.createObjectURL(file);
+        const removeBtn = document.createElement('button');
+        removeBtn.className = 'remove-file';
+        removeBtn.textContent = '×';
+        removeBtn.onclick = (e) => { e.stopPropagation(); selectedFiles.splice(i, 1); renderFilePreview(); };
+        const nameEl = document.createElement('div');
+        nameEl.className = 'file-name';
+        nameEl.textContent = file.name;
+        div.append(img, removeBtn, nameEl);
+        gallery.appendChild(div);
+    });
+}
+
+function clearFiles() {
+    selectedFiles = [];
+    document.getElementById('ds-image-input').value = '';
+    renderFilePreview();
+}
+
+async function processScreenshots() {
+    if (selectedFiles.length === 0) return;
+    const processBtn = document.getElementById('ds-process-btn');
+    const progressWrap = document.getElementById('ds-progress-wrap');
+    const progressBar  = document.getElementById('ds-progress-bar');
+    const progressLabel = document.getElementById('ds-progress-label');
+    const progressTime  = document.getElementById('ds-progress-time');
+
+    processBtn.disabled = true;
+    processBtn.textContent = '⏳ Processing…';
+    progressWrap.style.display = 'block';
+    progressBar.style.width = '0%';
+    progressLabel.textContent = `Processing ${selectedFiles.length} image${selectedFiles.length > 1 ? 's' : ''}…`;
+
+    let pct = 0;
+    const startMs = Date.now();
+    const timer = setInterval(() => {
+        pct += (90 - pct) * 0.12;
+        progressBar.style.width = pct.toFixed(1) + '%';
+        progressTime.textContent = ((Date.now() - startMs) / 1000).toFixed(0) + 's';
+    }, 300);
+
+    try {
+        const formData = new FormData();
+        selectedFiles.forEach(f => formData.append('images[]', f));
+
+        const res = await fetch('/api/desert-storm/process-screenshots', { method: 'POST', body: formData });
+        if (!res.ok) { showToast('OCR processing failed', 'error'); return; }
+
+        const result = await res.json();
+        if (!result || !result.participants || result.participants.length === 0) {
+            showToast('No players detected. Check screenshot format.', 'warning');
+            return;
+        }
+        document.getElementById('event-modal').style.display = 'none';
+        progressBar.style.width = '100%';
+        setTimeout(() => { progressWrap.style.display = 'none'; }, 600);
+        showPreview(result);
+    } catch (e) {
+        showToast('OCR processing failed: ' + e.message, 'error');
+        progressWrap.style.display = 'none';
+    } finally {
+        clearInterval(timer);
+        processBtn.disabled = false;
+        processBtn.textContent = '🔍 Process Screenshots with OCR';
+    }
+}
+
+// ---- OCR preview (single event) ----
+async function loadDSMembers() {
+    try {
+        const res = await fetch('/api/members');
+        if (!res.ok) return;
+        const data = await res.json();
+        dsAllMembers = (data || []).sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+    } catch { /* non-critical */ }
+}
+
+function buildDSMemberOptions(memberId) {
+    let opts = '<option value="">— Unmatched —</option>';
+    for (const m of dsAllMembers) {
+        const nick = m.nickname ? ` [${m.nickname}]` : '';
+        const sel = m.id === memberId ? ' selected' : '';
+        opts += `<option value="${m.id}"${sel}>${escapeHtml(m.name)}${escapeHtml(nick)} (${escapeHtml(m.rank)})</option>`;
+    }
+    return opts;
+}
+
+function showPreview(result) {
+    ocrResult = {
+        event_date: result.event_date || '',
+        total_damage: result.total_damage || 0,
+        existing_event_id: result.existing_event_id || null,
+        notes: '',
+        rows: (result.participants || []).map(p => ({
+            rank_in_event: p.rank_in_event,
+            name_snapshot: p.name_snapshot || '',
+            alliance_tag: p.alliance_tag || '',
+            damage: p.damage || 0,
+            member_id: p.member_id || null,
+            member_name: p.member_name || '',
+        })),
+    };
+    renderPreview();
+    document.getElementById('ds-ocr-modal').style.display = 'flex';
+}
+
+function renderPreview() {
+    const container = document.getElementById('ds-ocr-event');
+    const overwrite = ocrResult.existing_event_id
+        ? `<div class="info-banner info-banner--warning" style="margin-bottom:.5rem;">
+               <div class="info-content"><div class="info-icon">⚠️</div>
+               <div class="info-text">Event already exists for this date — importing will overwrite it.</div>
+               </div></div>`
+        : '';
+
+    let memberRows = '';
+    ocrResult.rows.forEach((row, rIdx) => {
+        const isTop = row.rank_in_event === 1;
+        const opts = buildDSMemberOptions(row.member_id);
+        memberRows += `<tr${isTop ? ' class="mg-mvp-row"' : ''}>
+            <td class="mg-rank-col">${isTop ? '🏆' : row.rank_in_event}</td>
+            <td class="mg-name-col">
+                <input class="mg-cell-input" data-field="name_snapshot" data-row="${rIdx}"
+                    value="${escapeAttr(row.name_snapshot)}" placeholder="Player name">
+                <input class="mg-cell-input" data-field="alliance_tag" data-row="${rIdx}"
+                    value="${escapeAttr(row.alliance_tag)}" placeholder="[TAG]" style="width:90px;">
+            </td>
+            <td class="mg-dmg-col">
+                <input class="mg-cell-input" data-field="damage" data-row="${rIdx}"
+                    value="${escapeAttr(String(row.damage))}" placeholder="0" style="width:110px;">
+            </td>
+            <td class="mg-name-col">
+                <select class="mg-member-select" data-row="${rIdx}">${opts}</select>
+            </td>
+        </tr>`;
+    });
+
+    container.innerHTML = `
+        <div class="mg-v2-card-header">
+            <div class="mg-card-meta">
+                <strong class="mg-event-date">📅 Desert Storm ranking</strong>
+            </div>
+            <div class="mg-card-controls">
+                <input type="date" id="ds-preview-date" value="${escapeAttr(ocrResult.event_date)}" title="Event date">
+                <input type="text" id="ds-preview-notes" value="" placeholder="Notes (optional)" title="Event notes">
+            </div>
+        </div>
+        ${overwrite}
+        <div class="rk-table-wrapper" style="max-height:420px;overflow-y:auto;">
+            <table class="rk-table">
+                <thead><tr><th class="mg-rank-col">#</th><th>Player</th><th class="mg-dmg-col">Points</th><th>Member</th></tr></thead>
+                <tbody>${memberRows}</tbody>
+            </table>
+        </div>`;
+}
+
+// Sync inline edits back into ocrResult live data.
+document.addEventListener('input', e => {
+    const t = e.target;
+    if (t.classList.contains('mg-cell-input')) {
+        const rIdx = parseInt(t.dataset.row);
+        const field = t.dataset.field;
+        if (!isNaN(rIdx)) ocrResult.rows[rIdx][field] = t.value;
+    }
+    if (t.id === 'ds-preview-date') ocrResult.event_date = t.value;
+    if (t.id === 'ds-preview-notes') ocrResult.notes = t.value;
+});
+
+document.addEventListener('change', e => {
+    const t = e.target;
+    if (t.classList.contains('mg-member-select')) {
+        const rIdx = parseInt(t.dataset.row);
+        if (!isNaN(rIdx)) {
+            ocrResult.rows[rIdx].member_id = t.value ? parseInt(t.value) : null;
+        }
+    }
+});
+
+async function importEvent() {
+    if (!ocrResult) return;
+    if (!ocrResult.event_date) { showToast('Event date is required', 'warning'); return; }
+
+    const participants = [];
+    for (const row of ocrResult.rows) {
+        const name = (row.name_snapshot || '').trim();
+        const dmgStr = String(row.damage || '').trim();
+        if (!name && !dmgStr) continue;
+        participants.push({
+            rank_in_event: row.rank_in_event,
+            name_snapshot: name,
+            alliance_tag: row.alliance_tag || '',
+            damage: parsePoints(dmgStr),
+            member_id: row.member_id || null,
+        });
+    }
+
+    const totalDamage = participants.reduce((s, p) => s + (p.damage || 0), 0);
+
+    const body = {
+        event_date: ocrResult.event_date,
+        total_damage: totalDamage,
+        notes: ocrResult.notes || '',
+        participants,
+    };
+    if (ocrResult.existing_event_id) body.overwrite_event_id = ocrResult.existing_event_id;
+
+    try {
+        const btn = document.getElementById('ds-ocr-import-btn');
+        if (btn) { btn.disabled = true; btn.textContent = '⏳ Importing…'; }
+
+        const res = await fetch('/api/desert-storm/confirm', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const data = await res.json();
+        if (res.ok) {
+            showToast(data.message || 'Event imported', 'success');
+            document.getElementById('ds-ocr-modal').style.display = 'none';
+            ocrResult = null;
+            clearFiles();
+            loadEvents();
+            loadMemberStats();
+        } else {
+            showToast(data.message || 'Import failed', 'error');
+            if (btn) { btn.disabled = false; btn.textContent = '✔ Import Event'; }
+        }
+    } catch (e) {
+        showToast('Import failed: ' + e.message, 'error');
+    }
+}
+
+// ---- Manual event creation ----
+function initManualForm() {
+    document.getElementById('event-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const date = document.getElementById('ds-date').value;
+        if (!date) { showToast('Date is required', 'warning'); return; }
+
+        try {
+            const res = await fetch('/api/desert-storm', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    event_date: date,
+                    total_alliance_damage: parseInt(document.getElementById('ds-total-damage').value) || 0,
+                    notes: document.getElementById('ds-notes').value,
+                }),
+            });
+            if (res.ok) {
+                showToast('Event created', 'success');
+                document.getElementById('event-modal').style.display = 'none';
+                document.getElementById('event-form').reset();
+                loadEvents();
+            } else {
+                showToast('Failed to create event', 'error');
+            }
+        } catch { showToast('Failed to create event', 'error'); }
+    });
+}
+
+// ---- Modal management ----
+function initModals() {
+    document.getElementById('add-event-btn').addEventListener('click', () => {
+        document.getElementById('event-modal').style.display = 'flex';
+    });
+
+    document.querySelectorAll('.modal .close').forEach(btn => {
+        btn.addEventListener('click', () => btn.closest('.modal').style.display = 'none');
+    });
+
+    document.querySelectorAll('.modal').forEach(modal => {
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) modal.style.display = 'none';
+        });
+    });
+
+    document.getElementById('ds-ocr-cancel-btn').addEventListener('click', () => {
+        document.getElementById('ds-ocr-modal').style.display = 'none';
+        ocrResult = null;
+        clearFiles();
+    });
+    document.getElementById('ds-ocr-import-btn').addEventListener('click', importEvent);
+}
+
+// ---- Search filter ----
+function initSearch() {
+    const input = document.getElementById('stats-search');
+    input.addEventListener('input', () => {
+        const q = input.value.toLowerCase();
+        const rows = document.querySelectorAll('#ds-stats-table tbody tr');
+        rows.forEach(row => {
+            const name = row.cells[0].textContent.toLowerCase();
+            row.style.display = name.includes(q) ? '' : 'none';
+        });
+    });
+}
+
+// ---- Points parsing/formatting ----
+function parsePoints(s) {
+    if (!s) return 0;
+    const clean = String(s).replace(/[^0-9]/g, '');
+    const n = parseInt(clean, 10);
+    return isNaN(n) ? 0 : n;
+}
+
+function formatPoints(val) {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n === 0) return '0';
+    return n.toLocaleString('en-US');
+}
+
+function escapeAttr(str) {
+    if (!str) return '';
+    return str.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// ---- Init ----
+document.addEventListener('DOMContentLoaded', async () => {
+    const authed = await checkAuth();
+    if (!authed) return;
+
+    initTabs();
+    initModals();
+    initUpload();
+    initManualForm();
+    initSearch();
+
+    await Promise.all([loadEvents(), loadMemberStats(), loadDSMembers()]);
+});

--- a/static/navigation.js
+++ b/static/navigation.js
@@ -51,6 +51,7 @@
                 <a href="/rankings.html" class="nav-link">📊 Rankings</a>
                 <a href="/storm.html" class="nav-link">🏜️ Storm</a>
                 <a href="/marshal-guard.html" class="nav-link" id="mg-nav-link">🛡️ Marshal Guard</a>
+                <a href="/desert-storm.html" class="nav-link" id="ds-nav-link">🏜️ Desert Storm</a>
                 <a href="/vs.html" class="nav-link">⚔️ VS Points</a>
                 <a href="/vs-compliance.html" class="nav-link">✅ VS Compliance</a>
                 <a href="/participation.html" class="nav-link">📋 Participation</a>

--- a/static/navigation.js
+++ b/static/navigation.js
@@ -52,6 +52,7 @@
                 <a href="/storm.html" class="nav-link">🏜️ Storm</a>
                 <a href="/marshal-guard.html" class="nav-link" id="mg-nav-link">🛡️ Marshal Guard</a>
                 <a href="/desert-storm.html" class="nav-link" id="ds-nav-link">🏜️ Desert Storm</a>
+                <a href="/zombie-siege.html" class="nav-link" id="zs-nav-link">🧟 Zombie Siege</a>
                 <a href="/vs.html" class="nav-link">⚔️ VS Points</a>
                 <a href="/vs-compliance.html" class="nav-link">✅ VS Compliance</a>
                 <a href="/participation.html" class="nav-link">📋 Participation</a>

--- a/static/settings.html
+++ b/static/settings.html
@@ -254,6 +254,17 @@
                     </div>
 
                     <div class="settings-group">
+                        <h4>🧟 Zombie Siege</h4>
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="zombie-siege-enabled">
+                                Enable Zombie Siege
+                            </label>
+                            <span class="help-text">When enabled, officers can record Zombie Siege events and import wave rankings from screenshots.</span>
+                        </div>
+                    </div>
+
+                    <div class="settings-group">
                         <h4>⏰ Train Schedule Times</h4>
                         <div class="form-group">
                             <label for="conductor-time">Conductor Time (Game Timezone):</label>

--- a/static/settings.html
+++ b/static/settings.html
@@ -243,6 +243,17 @@
                     </div>
 
                     <div class="settings-group">
+                        <h4>🏜️ Desert Storm</h4>
+                        <div class="form-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" id="desert-storm-enabled">
+                                Enable Desert Storm
+                            </label>
+                            <span class="help-text">When enabled, officers can record Desert Storm events and import individual point rankings from screenshots.</span>
+                        </div>
+                    </div>
+
+                    <div class="settings-group">
                         <h4>⏰ Train Schedule Times</h4>
                         <div class="form-group">
                             <label for="conductor-time">Conductor Time (Game Timezone):</label>

--- a/static/settings.js
+++ b/static/settings.js
@@ -58,6 +58,10 @@ async function loadSettings() {
         // Marshal Guard
         const mgEnabled = settings.marshal_guard_enabled !== undefined ? settings.marshal_guard_enabled : true;
         document.getElementById('marshal-guard-enabled').checked = mgEnabled;
+
+        // Desert Storm
+        const dsEnabled = settings.desert_storm_enabled !== undefined ? settings.desert_storm_enabled : true;
+        document.getElementById('desert-storm-enabled').checked = dsEnabled;
     } catch (error) {
         console.error('Error loading settings:', error);
         showToast('Failed to load settings.', 'error');
@@ -92,6 +96,7 @@ document.getElementById('settings-form').addEventListener('submit', async (e) =>
         power_tracking_enabled: document.getElementById('power-tracking-enabled').checked,
         vip_seat_enabled: document.getElementById('vip-seat-enabled').checked,
         marshal_guard_enabled: document.getElementById('marshal-guard-enabled').checked,
+        desert_storm_enabled: document.getElementById('desert-storm-enabled').checked,
         server_timezone: document.getElementById('server-timezone').value,
         conductor_time: document.getElementById('conductor-time').value,
         backup_time: document.getElementById('backup-time').value,

--- a/static/settings.js
+++ b/static/settings.js
@@ -62,6 +62,10 @@ async function loadSettings() {
         // Desert Storm
         const dsEnabled = settings.desert_storm_enabled !== undefined ? settings.desert_storm_enabled : true;
         document.getElementById('desert-storm-enabled').checked = dsEnabled;
+
+        // Zombie Siege
+        const zsEnabled = settings.zombie_siege_enabled !== undefined ? settings.zombie_siege_enabled : true;
+        document.getElementById('zombie-siege-enabled').checked = zsEnabled;
     } catch (error) {
         console.error('Error loading settings:', error);
         showToast('Failed to load settings.', 'error');
@@ -97,6 +101,7 @@ document.getElementById('settings-form').addEventListener('submit', async (e) =>
         vip_seat_enabled: document.getElementById('vip-seat-enabled').checked,
         marshal_guard_enabled: document.getElementById('marshal-guard-enabled').checked,
         desert_storm_enabled: document.getElementById('desert-storm-enabled').checked,
+        zombie_siege_enabled: document.getElementById('zombie-siege-enabled').checked,
         server_timezone: document.getElementById('server-timezone').value,
         conductor_time: document.getElementById('conductor-time').value,
         backup_time: document.getElementById('backup-time').value,

--- a/static/styles.css
+++ b/static/styles.css
@@ -7409,6 +7409,7 @@ section:last-child {
     max-width: 100%;
 }
 .mg-member-select--warn { border-color: var(--warning, #f59e0b); }
+.zs-warn-row { background: var(--warning-light, #fef3c7); }
 .mg-ocr-hint  { font-size: .73em; color: var(--text-muted, #9ca3af); font-style: italic; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 /* Status icon */

--- a/static/zombie-siege.html
+++ b/static/zombie-siege.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zombie Siege - Last War Alliance</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="branding.js"></script>
+    <script src="toast.js"></script>
+    <script src="common.js"></script>
+    <script src="navigation.js"></script>
+</head>
+<body data-h1="🧟 Last War: Survival" data-subtitle="Zombie Siege individual wave rankings. Someone has to keep score.">
+    <div class="container">
+
+        <main>
+            <!-- Tab Buttons -->
+            <div class="tab-buttons">
+                <button class="tab-btn active" data-tab="events">🗓️ Events</button>
+                <button class="tab-btn" data-tab="stats">📊 Member Stats</button>
+            </div>
+
+            <!-- Events Tab -->
+            <div id="tab-events" class="tab-content active">
+                <section class="form-section">
+                    <div class="mg-toolbar">
+                        <h3>🧟 Zombie Siege Events</h3>
+                        <button id="add-event-btn" class="primary-btn uploader-only" style="display:none;">➕ Add Event</button>
+                    </div>
+                    <div id="event-list" class="rk-table-wrapper">
+                        <p class="loading">⏳ Loading events...</p>
+                    </div>
+                </section>
+            </div>
+
+            <!-- Member Stats Tab -->
+            <div id="tab-stats" class="tab-content">
+                <section class="form-section">
+                    <div class="mg-toolbar">
+                        <h3>📊 Member Statistics</h3>
+                        <input type="text" id="stats-search" class="form-control mg-search" placeholder="🔍 Search member...">
+                    </div>
+                    <div id="stats-list" class="rk-table-wrapper">
+                        <p class="loading">⏳ Loading stats...</p>
+                    </div>
+                </section>
+            </div>
+        </main>
+
+    </div>
+
+    <!-- Add Event Modal -->
+    <div id="event-modal" class="modal" style="display:none;">
+        <div class="modal-content">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3 id="event-modal-title">Add Event</h3>
+            <form id="event-form">
+
+                <div class="tab-buttons">
+                    <button type="button" class="tab-btn active" data-modal-tab="upload">📷 Screenshot Upload</button>
+                    <button type="button" class="tab-btn" data-modal-tab="manual">✍️ Manual Entry</button>
+                </div>
+
+                <!-- Upload sub-tab -->
+                <div id="modal-tab-upload" class="modal-tab-content active">
+                    <input type="file" id="zs-image-input" accept="image/*" multiple style="display:none;">
+                    <div id="zs-drop-zone" class="drop-zone">
+                        <div id="zs-drop-content">
+                            <div class="drop-icon">📁</div>
+                            <p class="drop-text">Tap to upload or drag &amp; drop</p>
+                            <p class="drop-subtext">Zombie Siege ranking screenshots (up to 40 images)</p>
+                        </div>
+                        <div id="zs-preview-container" class="preview-container">
+                            <div class="preview-header">
+                                <p id="zs-files-count"></p>
+                                <button type="button" id="zs-clear-btn" class="btn btn-secondary">🗑️ Clear</button>
+                            </div>
+                            <div id="zs-preview-gallery"></div>
+                        </div>
+                    </div>
+                    <button type="button" id="zs-process-btn" class="btn btn-primary" style="display:none;">🔍 Process Screenshots with OCR</button>
+                    <div id="zs-progress-wrap" style="display:none;margin-top:.75rem;">
+                        <div style="display:flex;justify-content:space-between;font-size:.82em;margin-bottom:.3rem;">
+                            <span id="zs-progress-label">Processing…</span>
+                            <span id="zs-progress-time">0s</span>
+                        </div>
+                        <div style="background:var(--bg-secondary,#e5e7eb);border-radius:999px;height:8px;overflow:hidden;">
+                            <div id="zs-progress-bar" style="height:100%;width:0%;background:var(--primary,#6366f1);border-radius:999px;transition:width .3s ease;"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Manual sub-tab -->
+                <div id="modal-tab-manual" class="modal-tab-content">
+                    <div class="form-group">
+                        <label for="zs-date">Event Date</label>
+                        <input type="date" id="zs-date" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="zs-total-waves">Total Alliance Waves</label>
+                        <input type="number" id="zs-total-waves" min="0" placeholder="e.g. 20">
+                    </div>
+                    <div class="form-group">
+                        <label for="zs-notes">Notes (optional)</label>
+                        <textarea id="zs-notes" rows="2" placeholder="Any notes about this event..."></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary">💾 Save Event</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- OCR Preview Modal (single event, per-row editing) -->
+    <div id="zs-ocr-modal" class="modal" style="display:none;">
+        <div class="modal-content" style="max-width:800px;">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3>📋 OCR Preview — Review &amp; Import</h3>
+            <p class="text-muted" style="margin-top:0;font-size:0.9em;">
+                Edit any cell before importing. Unmatched players need a member selected.
+            </p>
+            <div id="zs-ocr-event"></div>
+            <div class="modal-footer" style="margin-top:1rem;">
+                <button type="button" id="zs-ocr-cancel-btn" class="secondary-btn">Cancel</button>
+                <button type="button" id="zs-ocr-import-btn" class="primary-btn">✔ Import Event</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Event Detail Modal -->
+    <div id="detail-modal" class="modal" style="display:none;">
+        <div class="modal-content" style="max-width:700px;">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3 id="detail-modal-title">Event Details</h3>
+            <div id="detail-summary"></div>
+            <div id="detail-participants" class="rk-table-wrapper"></div>
+        </div>
+    </div>
+
+    <script src="theme.js"></script>
+    <script src="zombie-siege.js"></script>
+</body>
+</html>

--- a/static/zombie-siege.js
+++ b/static/zombie-siege.js
@@ -349,6 +349,7 @@ function showPreview(result) {
             waves: p.waves || 0,
             member_id: p.member_id || null,
             member_name: p.member_name || '',
+            warnings: p.warnings || [],
         })),
     };
     renderPreview();
@@ -367,10 +368,16 @@ function renderPreview() {
     let memberRows = '';
     ocrResult.rows.forEach((row, rIdx) => {
         const isTop = row.rank_in_event === 1;
+        const hasWarnings = (row.warnings || []).length > 0;
+        const cls = [isTop ? 'mg-mvp-row' : '', hasWarnings ? 'zs-warn-row' : ''].filter(Boolean).join(' ');
+        const warnBadge = hasWarnings
+            ? `<span class="zs-warn-badge" title="${escapeAttr(row.warnings.join('; '))}">⚠️</span>`
+            : '';
         const opts = buildZSMemberOptions(row.member_id);
-        memberRows += `<tr${isTop ? ' class="mg-mvp-row"' : ''}>
+        memberRows += `<tr${cls ? ` class="${cls}"` : ''}>
             <td class="mg-rank-col">${isTop ? '🏆' : row.rank_in_event}</td>
             <td class="mg-name-col">
+                ${warnBadge}
                 <input class="mg-cell-input" data-field="name_snapshot" data-row="${rIdx}"
                     value="${escapeAttr(row.name_snapshot)}" placeholder="Player name">
                 <input class="mg-cell-input" data-field="alliance_tag" data-row="${rIdx}"
@@ -411,7 +418,18 @@ document.addEventListener('input', e => {
     if (t.classList.contains('mg-cell-input')) {
         const rIdx = parseInt(t.dataset.row);
         const field = t.dataset.field;
-        if (!isNaN(rIdx)) ocrResult.rows[rIdx][field] = t.value;
+        if (!isNaN(rIdx)) {
+            ocrResult.rows[rIdx][field] = t.value;
+            // User-corrected values are authoritative — clear OCR warnings.
+            if (field === 'name_snapshot' || field === 'waves') {
+                ocrResult.rows[rIdx].warnings = [];
+                const tr = t.closest('tr');
+                if (tr) {
+                    tr.classList.remove('zs-warn-row');
+                    tr.querySelector('.zs-warn-badge')?.remove();
+                }
+            }
+        }
     }
     if (t.id === 'zs-preview-date') ocrResult.event_date = t.value;
     if (t.id === 'zs-preview-notes') ocrResult.notes = t.value;

--- a/static/zombie-siege.js
+++ b/static/zombie-siege.js
@@ -1,0 +1,581 @@
+// Zombie Siege page logic
+let canUpload = false; // R3, R4, R5, admin — can upload screenshots & import events
+let isOfficer = false; // R4, R5, admin — can edit/delete events
+let isAdmin = false;
+let selectedFiles = [];
+let ocrResult = null; // single DesertStormOCRResult preview
+let zsAllMembers = [];
+
+async function checkAuth() {
+    try {
+        const res = await fetch('/api/check-auth');
+        const data = await res.json();
+        if (!data.authenticated) { window.location.href = '/login.html'; return false; }
+        if (data.must_change_password) { window.location.href = '/profile.html?must_change_password=1'; return false; }
+
+        let display = `👤 ${data.username}`;
+        if (data.rank) display += ` (${data.rank})`;
+        const usernameDisplay = document.getElementById('username-display');
+        if (usernameDisplay) {
+            usernameDisplay.textContent = display;
+            usernameDisplay.addEventListener('click', toggleUserDropdown);
+        }
+
+        const logoutBtn = document.getElementById('dropdown-logout-btn');
+        if (logoutBtn) logoutBtn.addEventListener('click', handleLogout);
+
+        document.addEventListener('click', (event) => {
+            const dropdown = document.getElementById('user-dropdown-menu');
+            const btn = document.getElementById('username-display');
+            if (dropdown && btn && !btn.contains(event.target) && !dropdown.contains(event.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
+
+        isAdmin = data.is_admin || false;
+        const rank = (data.rank || '').toUpperCase();
+        canUpload = isAdmin || rank === 'R3' || rank === 'R4' || rank === 'R5';
+        isOfficer = isAdmin || rank === 'R4' || rank === 'R5';
+
+        if (canUpload) {
+            document.querySelectorAll('.uploader-only').forEach(el => el.style.display = '');
+        }
+        if (isOfficer) {
+            document.querySelectorAll('.officer-only').forEach(el => el.style.display = '');
+        }
+        if (isAdmin) {
+            const adminLink = document.getElementById('admin-nav-link');
+            const gyLink = document.getElementById('graveyard-nav-link');
+            if (adminLink) adminLink.style.display = 'block';
+            if (gyLink) gyLink.style.display = 'block';
+        }
+        return true;
+    } catch { return false; }
+}
+
+// ---- Tab switching ----
+function initTabs() {
+    document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.tab-btn[data-tab]').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+            btn.classList.add('active');
+            document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+        });
+    });
+    // Modal sub-tabs
+    document.querySelectorAll('[data-modal-tab]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('[data-modal-tab]').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.modal-tab-content').forEach(c => c.classList.remove('active'));
+            btn.classList.add('active');
+            document.getElementById('modal-tab-' + btn.dataset.modalTab).classList.add('active');
+        });
+    });
+}
+
+// ---- Event list ----
+async function loadEvents() {
+    try {
+        const res = await fetch('/api/zombie-siege');
+        const events = await res.json();
+        renderEventList(events);
+    } catch (e) {
+        document.getElementById('event-list').innerHTML = '<p class="empty">⚠️ Failed to load events.</p>';
+    }
+}
+
+function renderEventList(events) {
+    const el = document.getElementById('event-list');
+    if (!events || events.length === 0) {
+        el.innerHTML = '<p class="empty">🧟 No Zombie Siege events recorded yet.</p>';
+        return;
+    }
+    let html = `<table class="rk-table"><thead><tr>
+        <th>Date</th><th>Total Waves</th><th># Players</th><th>Top Defender</th><th>Top Waves</th>`;
+    if (isOfficer) html += '<th>Actions</th>';
+    html += '</tr></thead><tbody>';
+    for (const ev of events) {
+        html += `<tr class="mg-event-row" data-id="${ev.id}">
+            <td>${ev.event_date}</td>
+            <td>${formatWaves(ev.total_waves)}</td>
+            <td>${ev.participant_count}</td>
+            <td>${escapeHtml(ev.top_wave_defender)}</td>
+            <td>${formatWaves(ev.top_waves)}</td>`;
+        if (isOfficer) {
+            html += `<td class="list-actions">
+                <button class="edit-schedule-btn" onclick="event.stopPropagation(); deleteEvent(${ev.id})" title="Delete">🗑️</button>
+            </td>`;
+        }
+        html += '</tr>';
+    }
+    html += '</tbody></table>';
+    el.innerHTML = html;
+
+    el.querySelectorAll('.mg-event-row').forEach(row => {
+        row.style.cursor = 'pointer';
+        row.addEventListener('click', () => viewEventDetail(parseInt(row.dataset.id)));
+    });
+}
+
+async function viewEventDetail(id) {
+    try {
+        const res = await fetch('/api/zombie-siege/' + id);
+        const ev = await res.json();
+        document.getElementById('detail-modal-title').textContent = `🧟 Event: ${ev.event_date}`;
+        document.getElementById('detail-summary').innerHTML = `
+            <p><strong>Total Alliance Waves:</strong> ${formatWaves(ev.total_waves)}</p>
+            ${ev.notes ? '<p><strong>Notes:</strong> ' + escapeHtml(ev.notes) + '</p>' : ''}
+            <p><strong>Participants:</strong> ${ev.participants.length}</p>`;
+        let thtml = `<table class="rk-table"><thead><tr>
+            <th>#</th><th>Player</th><th>Waves</th><th>Member</th>
+        </tr></thead><tbody>`;
+        for (const p of ev.participants) {
+            const matched = p.member_id ? `✅ ${escapeHtml(p.member_name)}` : '❌ Unmatched';
+            thtml += `<tr${p.rank_in_event === 1 ? ' class="mg-mvp-row"' : ''}>
+                <td>${p.rank_in_event === 1 ? '🏆' : p.rank_in_event}</td>
+                <td>${escapeHtml(p.name_snapshot)}${p.alliance_tag ? ' <span class="text-muted">[' + escapeHtml(p.alliance_tag) + ']</span>' : ''}</td>
+                <td>${formatWaves(p.waves)}</td>
+                <td>${matched}</td>
+            </tr>`;
+        }
+        thtml += '</tbody></table>';
+        document.getElementById('detail-participants').innerHTML = thtml;
+        document.getElementById('detail-modal').style.display = 'flex';
+    } catch (e) {
+        showToast('Failed to load event details', 'error');
+    }
+}
+
+async function deleteEvent(id) {
+    if (!confirm('Delete this Zombie Siege event and all its participants?')) return;
+    try {
+        const res = await fetch('/api/zombie-siege/' + id, { method: 'DELETE' });
+        if (res.ok) {
+            showToast('Event deleted', 'success');
+            loadEvents();
+        } else {
+            showToast('Failed to delete event', 'error');
+        }
+    } catch { showToast('Failed to delete event', 'error'); }
+}
+
+// ---- Member stats ----
+async function loadMemberStats() {
+    try {
+        const res = await fetch('/api/zombie-siege/member-stats');
+        const stats = await res.json();
+        renderMemberStats(stats);
+    } catch {
+        document.getElementById('stats-list').innerHTML = '<p class="empty">⚠️ Failed to load stats.</p>';
+    }
+}
+
+function renderMemberStats(stats) {
+    const el = document.getElementById('stats-list');
+    if (!stats || stats.length === 0) {
+        el.innerHTML = '<p class="empty">🧟 No participation data yet.</p>';
+        return;
+    }
+    let html = `<table class="rk-table" id="zs-stats-table"><thead><tr>
+        <th>Member</th><th>Rank</th><th>Events</th><th>Total Waves</th><th>Avg Rank</th><th>Best Waves</th>
+    </tr></thead><tbody>`;
+    for (const s of stats) {
+        html += `<tr>
+            <td>${escapeHtml(s.member_name)}</td>
+            <td>${escapeHtml(s.member_rank)}</td>
+            <td>${s.event_count}</td>
+            <td>${formatWaves(s.total_waves)}</td>
+            <td>${s.avg_rank.toFixed(1)}</td>
+            <td>${formatWaves(s.best_waves)}</td>
+        </tr>`;
+    }
+    html += '</tbody></table>';
+    el.innerHTML = html;
+}
+
+// ---- Upload / OCR flow ----
+function initUpload() {
+    const dropZone = document.getElementById('zs-drop-zone');
+    const fileInput = document.getElementById('zs-image-input');
+    const processBtn = document.getElementById('zs-process-btn');
+    const clearBtn = document.getElementById('zs-clear-btn');
+
+    dropZone.addEventListener('click', (e) => {
+        if (e.target.closest('button')) return;
+        fileInput.click();
+    });
+    dropZone.addEventListener('dragover', (e) => { e.preventDefault(); dropZone.classList.add('dragover'); });
+    dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+    dropZone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        dropZone.classList.remove('dragover');
+        handleFiles(e.dataTransfer.files);
+    });
+    fileInput.addEventListener('change', () => handleFiles(fileInput.files));
+    clearBtn.addEventListener('click', clearFiles);
+    processBtn.addEventListener('click', processScreenshots);
+}
+
+function handleFiles(fileList) {
+    const files = Array.from(fileList).filter(f => f.type.startsWith('image/'));
+    if (files.length === 0) return;
+    selectedFiles = selectedFiles.concat(files).slice(0, 40);
+    renderFilePreview();
+}
+
+function renderFilePreview() {
+    const gallery = document.getElementById('zs-preview-gallery');
+    const container = document.getElementById('zs-preview-container');
+    const dropContent = document.getElementById('zs-drop-content');
+    const processBtn = document.getElementById('zs-process-btn');
+    const countEl = document.getElementById('zs-files-count');
+
+    if (selectedFiles.length === 0) {
+        container.style.display = 'none';
+        dropContent.style.display = '';
+        processBtn.style.display = 'none';
+        return;
+    }
+
+    dropContent.style.display = 'none';
+    container.style.display = 'block';
+    processBtn.style.display = 'block';
+    countEl.textContent = `${selectedFiles.length} file${selectedFiles.length > 1 ? 's' : ''} selected`;
+
+    gallery.innerHTML = '';
+    selectedFiles.forEach((file, i) => {
+        const div = document.createElement('div');
+        div.className = 'preview-item';
+        const img = document.createElement('img');
+        img.className = 'preview-img';
+        img.src = URL.createObjectURL(file);
+        const removeBtn = document.createElement('button');
+        removeBtn.className = 'remove-file';
+        removeBtn.textContent = '×';
+        removeBtn.onclick = (e) => { e.stopPropagation(); selectedFiles.splice(i, 1); renderFilePreview(); };
+        const nameEl = document.createElement('div');
+        nameEl.className = 'file-name';
+        nameEl.textContent = file.name;
+        div.append(img, removeBtn, nameEl);
+        gallery.appendChild(div);
+    });
+}
+
+function clearFiles() {
+    selectedFiles = [];
+    document.getElementById('zs-image-input').value = '';
+    renderFilePreview();
+}
+
+async function processScreenshots() {
+    if (selectedFiles.length === 0) return;
+    const processBtn = document.getElementById('zs-process-btn');
+    const progressWrap = document.getElementById('zs-progress-wrap');
+    const progressBar  = document.getElementById('zs-progress-bar');
+    const progressLabel = document.getElementById('zs-progress-label');
+    const progressTime  = document.getElementById('zs-progress-time');
+
+    processBtn.disabled = true;
+    processBtn.textContent = '⏳ Processing…';
+    progressWrap.style.display = 'block';
+    progressBar.style.width = '0%';
+    progressLabel.textContent = `Processing ${selectedFiles.length} image${selectedFiles.length > 1 ? 's' : ''}…`;
+
+    let pct = 0;
+    const startMs = Date.now();
+    const timer = setInterval(() => {
+        pct += (90 - pct) * 0.12;
+        progressBar.style.width = pct.toFixed(1) + '%';
+        progressTime.textContent = ((Date.now() - startMs) / 1000).toFixed(0) + 's';
+    }, 300);
+
+    try {
+        const formData = new FormData();
+        selectedFiles.forEach(f => formData.append('images[]', f));
+
+        const res = await fetch('/api/zombie-siege/process-screenshots', { method: 'POST', body: formData });
+        if (!res.ok) { showToast('OCR processing failed', 'error'); return; }
+
+        const result = await res.json();
+        if (!result || !result.participants || result.participants.length === 0) {
+            showToast('No players detected. Check screenshot format.', 'warning');
+            return;
+        }
+        document.getElementById('event-modal').style.display = 'none';
+        progressBar.style.width = '100%';
+        setTimeout(() => { progressWrap.style.display = 'none'; }, 600);
+        showPreview(result);
+    } catch (e) {
+        showToast('OCR processing failed: ' + e.message, 'error');
+        progressWrap.style.display = 'none';
+    } finally {
+        clearInterval(timer);
+        processBtn.disabled = false;
+        processBtn.textContent = '🔍 Process Screenshots with OCR';
+    }
+}
+
+// ---- OCR preview (single event) ----
+async function loadZSMembers() {
+    try {
+        const res = await fetch('/api/members');
+        if (!res.ok) return;
+        const data = await res.json();
+        zsAllMembers = (data || []).sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+    } catch { /* non-critical */ }
+}
+
+function buildZSMemberOptions(memberId) {
+    let opts = '<option value="">— Unmatched —</option>';
+    for (const m of zsAllMembers) {
+        const nick = m.nickname ? ` [${m.nickname}]` : '';
+        const sel = m.id === memberId ? ' selected' : '';
+        opts += `<option value="${m.id}"${sel}>${escapeHtml(m.name)}${escapeHtml(nick)} (${escapeHtml(m.rank)})</option>`;
+    }
+    return opts;
+}
+
+function showPreview(result) {
+    ocrResult = {
+        event_date: result.event_date || '',
+        total_waves: result.total_waves || 0,
+        existing_event_id: result.existing_event_id || null,
+        notes: '',
+        rows: (result.participants || []).map(p => ({
+            rank_in_event: p.rank_in_event,
+            name_snapshot: p.name_snapshot || '',
+            alliance_tag: p.alliance_tag || '',
+            waves: p.waves || 0,
+            member_id: p.member_id || null,
+            member_name: p.member_name || '',
+        })),
+    };
+    renderPreview();
+    document.getElementById('zs-ocr-modal').style.display = 'flex';
+}
+
+function renderPreview() {
+    const container = document.getElementById('zs-ocr-event');
+    const overwrite = ocrResult.existing_event_id
+        ? `<div class="info-banner info-banner--warning" style="margin-bottom:.5rem;">
+               <div class="info-content"><div class="info-icon">⚠️</div>
+               <div class="info-text">Event already exists for this date — importing will overwrite it.</div>
+               </div></div>`
+        : '';
+
+    let memberRows = '';
+    ocrResult.rows.forEach((row, rIdx) => {
+        const isTop = row.rank_in_event === 1;
+        const opts = buildZSMemberOptions(row.member_id);
+        memberRows += `<tr${isTop ? ' class="mg-mvp-row"' : ''}>
+            <td class="mg-rank-col">${isTop ? '🏆' : row.rank_in_event}</td>
+            <td class="mg-name-col">
+                <input class="mg-cell-input" data-field="name_snapshot" data-row="${rIdx}"
+                    value="${escapeAttr(row.name_snapshot)}" placeholder="Player name">
+                <input class="mg-cell-input" data-field="alliance_tag" data-row="${rIdx}"
+                    value="${escapeAttr(row.alliance_tag)}" placeholder="[TAG]" style="width:90px;">
+            </td>
+            <td class="mg-dmg-col">
+                <input class="mg-cell-input" data-field="waves" data-row="${rIdx}"
+                    value="${escapeAttr(String(row.waves))}" placeholder="0" style="width:110px;">
+            </td>
+            <td class="mg-name-col">
+                <select class="mg-member-select" data-row="${rIdx}">${opts}</select>
+            </td>
+        </tr>`;
+    });
+
+    container.innerHTML = `
+        <div class="mg-v2-card-header">
+            <div class="mg-card-meta">
+                <strong class="mg-event-date">📅 Zombie Siege ranking</strong>
+            </div>
+            <div class="mg-card-controls">
+                <input type="date" id="zs-preview-date" value="${escapeAttr(ocrResult.event_date)}" title="Event date">
+                <input type="text" id="zs-preview-notes" value="" placeholder="Notes (optional)" title="Event notes">
+            </div>
+        </div>
+        ${overwrite}
+        <div class="rk-table-wrapper" style="max-height:420px;overflow-y:auto;">
+            <table class="rk-table">
+                <thead><tr><th class="mg-rank-col">#</th><th>Player</th><th class="mg-dmg-col">Waves</th><th>Member</th></tr></thead>
+                <tbody>${memberRows}</tbody>
+            </table>
+        </div>`;
+}
+
+// Sync inline edits back into ocrResult live data.
+document.addEventListener('input', e => {
+    const t = e.target;
+    if (t.classList.contains('mg-cell-input')) {
+        const rIdx = parseInt(t.dataset.row);
+        const field = t.dataset.field;
+        if (!isNaN(rIdx)) ocrResult.rows[rIdx][field] = t.value;
+    }
+    if (t.id === 'zs-preview-date') ocrResult.event_date = t.value;
+    if (t.id === 'zs-preview-notes') ocrResult.notes = t.value;
+});
+
+document.addEventListener('change', e => {
+    const t = e.target;
+    if (t.classList.contains('mg-member-select')) {
+        const rIdx = parseInt(t.dataset.row);
+        if (!isNaN(rIdx)) {
+            ocrResult.rows[rIdx].member_id = t.value ? parseInt(t.value) : null;
+        }
+    }
+});
+
+async function importEvent() {
+    if (!ocrResult) return;
+    if (!ocrResult.event_date) { showToast('Event date is required', 'warning'); return; }
+
+    const participants = [];
+    for (const row of ocrResult.rows) {
+        const name = (row.name_snapshot || '').trim();
+        const wavesStr = String(row.waves || '').trim();
+        if (!name && !wavesStr) continue;
+        participants.push({
+            rank_in_event: row.rank_in_event,
+            name_snapshot: name,
+            alliance_tag: row.alliance_tag || '',
+            waves: parseWaves(wavesStr),
+            member_id: row.member_id || null,
+        });
+    }
+
+    const totalWaves = participants.reduce((s, p) => s + (p.waves || 0), 0);
+
+    const body = {
+        event_date: ocrResult.event_date,
+        total_waves: totalWaves,
+        notes: ocrResult.notes || '',
+        participants,
+    };
+    if (ocrResult.existing_event_id) body.overwrite_event_id = ocrResult.existing_event_id;
+
+    try {
+        const btn = document.getElementById('zs-ocr-import-btn');
+        if (btn) { btn.disabled = true; btn.textContent = '⏳ Importing…'; }
+
+        const res = await fetch('/api/zombie-siege/confirm', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const data = await res.json();
+        if (res.ok) {
+            showToast(data.message || 'Event imported', 'success');
+            document.getElementById('zs-ocr-modal').style.display = 'none';
+            ocrResult = null;
+            clearFiles();
+            loadEvents();
+            loadMemberStats();
+        } else {
+            showToast(data.message || 'Import failed', 'error');
+            if (btn) { btn.disabled = false; btn.textContent = '✔ Import Event'; }
+        }
+    } catch (e) {
+        showToast('Import failed: ' + e.message, 'error');
+    }
+}
+
+// ---- Manual event creation ----
+function initManualForm() {
+    document.getElementById('event-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const date = document.getElementById('zs-date').value;
+        if (!date) { showToast('Date is required', 'warning'); return; }
+
+        try {
+            const res = await fetch('/api/zombie-siege', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    event_date: date,
+                    total_waves: parseInt(document.getElementById('zs-total-waves').value) || 0,
+                    notes: document.getElementById('zs-notes').value,
+                }),
+            });
+            if (res.ok) {
+                showToast('Event created', 'success');
+                document.getElementById('event-modal').style.display = 'none';
+                document.getElementById('event-form').reset();
+                loadEvents();
+            } else {
+                showToast('Failed to create event', 'error');
+            }
+        } catch { showToast('Failed to create event', 'error'); }
+    });
+}
+
+// ---- Modal management ----
+function initModals() {
+    document.getElementById('add-event-btn').addEventListener('click', () => {
+        document.getElementById('event-modal').style.display = 'flex';
+    });
+
+    document.querySelectorAll('.modal .close').forEach(btn => {
+        btn.addEventListener('click', () => btn.closest('.modal').style.display = 'none');
+    });
+
+    document.querySelectorAll('.modal').forEach(modal => {
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) modal.style.display = 'none';
+        });
+    });
+
+    document.getElementById('zs-ocr-cancel-btn').addEventListener('click', () => {
+        document.getElementById('zs-ocr-modal').style.display = 'none';
+        ocrResult = null;
+        clearFiles();
+    });
+    document.getElementById('zs-ocr-import-btn').addEventListener('click', importEvent);
+}
+
+// ---- Search filter ----
+function initSearch() {
+    const input = document.getElementById('stats-search');
+    input.addEventListener('input', () => {
+        const q = input.value.toLowerCase();
+        const rows = document.querySelectorAll('#zs-stats-table tbody tr');
+        rows.forEach(row => {
+            const name = row.cells[0].textContent.toLowerCase();
+            row.style.display = name.includes(q) ? '' : 'none';
+        });
+    });
+}
+
+// ---- Waves parsing/formatting ----
+function parseWaves(s) {
+    if (!s) return 0;
+    const clean = String(s).replace(/[^0-9]/g, '');
+    const n = parseInt(clean, 10);
+    return isNaN(n) ? 0 : n;
+}
+
+function formatWaves(val) {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n === 0) return '0';
+    return n.toLocaleString('en-US');
+}
+
+function escapeAttr(str) {
+    if (!str) return '';
+    return str.replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// ---- Init ----
+document.addEventListener('DOMContentLoaded', async () => {
+    const authed = await checkAuth();
+    if (!authed) return;
+
+    initTabs();
+    initModals();
+    initUpload();
+    initManualForm();
+    initSearch();
+
+    await Promise.all([loadEvents(), loadMemberStats(), loadZSMembers()]);
+});


### PR DESCRIPTION
Adds two new alliance event trackers, each with full backend, OCR screenshot import, and a preview/edit/confirm flow.

## Desert Storm
- Event + participant tables, API endpoints, settings toggle, nav entry
- Word-box based OCR extractor (rewritten after validation against real screenshots; fixes rank-1 corruption)

## Zombie Siege
- Event + participant tables, API endpoints, settings toggle, nav entry
- Two-pass OCR extractor:
  - Pass 1: full-width 2x crop for names (30–42% name column with same-line continuation up to 60% for multi-word names) + right-column waves
  - Pass 2: right-column 4x crop for small wave numbers; best wave pass wins
- Junk filtering: `zsValidName` rejects symbol/two-char OCR junk; multi-screenshot merge dedupes players by name similarity

## OCR confidence warnings (manual review)
Rows the extractor is unsure about are flagged in the preview modal instead of silently imported:
- wave count unreadable (`waves == 0`)
- name looks like OCR garbage (multi-word with a short token, e.g. "Pte iit itt")

Flagged rows are tinted amber with a ⚠ badge; editing the cell clears the flag. Warnings union across duplicate screenshots and drop once a legible read arrives.

## Validation
All 13 Zombie Siege screenshots parse with 0 hard failures. Exactly the 2 known weak rows get flagged (junk name, wave=0); 28 clean rows unflagged. Multi-word names ("Theodore Silas") and previously lost names ("ThunderHunteR") recovered.

## Notes
- `screenshots/` test images are gitignored and not included
- No DB migration needed — tables are created on startup