### PR TITLE
fix: guard getAllianceShortName against nil db

### DIFF
--- a/main.go
+++ b/main.go
@@ -13977,6 +13977,9 @@ func loadAllMembers() ([]Member, error) {
 // getAllianceShortName returns the uppercase alliance short name from settings,
 // used as the known tag hint for player-tag parsing.
 func getAllianceShortName() string {
+	if db == nil {
+		return ""
+	}
 	var tag string
 	db.QueryRow(`SELECT COALESCE(alliance_short_name, '') FROM settings WHERE id = 1`).Scan(&tag)
 	return strings.ToUpper(strings.TrimSpace(tag))


### PR DESCRIPTION
Extractors call `getAllianceShortName` for the tag hint; with an uninitialized database (tests, tooling) this panicked with a nil pointer dereference. Return an empty tag instead.

Found while validating all 52 event screenshots against main after #58: 52/52 parse, 0 hard failures (Zombie Siege 13, Desert Storm 2, Member Growth 10, VS Monday 13, General Power 14). Member Growth uses the mask fallback on these screenshots since the row-based pass finds fewer than 3 participants.

3-line change.