### PR TITLE
fix(ocr): harden member screenshot extraction against garbled readings

### DIFF
--- a/main.go
+++ b/main.go
@@ -508,6 +508,35 @@ func areSimilar(name1, name2 string) bool {
 	return false
 }
 
+// bestSimilarMember finds the roster member that best matches an OCR-garbled
+// name. Stricter than areSimilar: similarity must be >= 0.8 or one name must
+// contain the other, so we only adopt canonical names we are confident about.
+func bestSimilarMember(nameLower string, existingMembers map[string]Member) (Member, bool) {
+	var best Member
+	bestScore := 0.0
+	for existingLower, em := range existingMembers {
+		dist := levenshteinDistance(nameLower, existingLower)
+		maxLen := max(len(nameLower), len(existingLower))
+		similarity := 1.0 - float64(dist)/float64(maxLen)
+		contains := len(nameLower) >= 3 && len(existingLower) >= 3 &&
+			(strings.Contains(nameLower, existingLower) || strings.Contains(existingLower, nameLower))
+		// Long names tolerate more absolute typos than short ones.
+		closeEdit := (dist <= 2 && maxLen >= 4) || (dist <= 3 && maxLen >= 10)
+		if similarity < 0.8 && !contains && !closeEdit {
+			continue
+		}
+		score := similarity
+		if contains {
+			score = 1.0 + similarity
+		}
+		if score > bestScore {
+			bestScore = score
+			best = em
+		}
+	}
+	return best, bestScore > 0
+}
+
 func max(a, b int) int {
 	if a > b {
 		return a
@@ -6694,6 +6723,8 @@ func importMemberScreenshot(w http.ResponseWriter, r *http.Request) {
 	// or "PlayerName  R4" or "PlayerName (R4)"
 	rankRe := regexp.MustCompile(`(?i)\bR([1-5])\b`)
 	validRanks := map[string]bool{"R1": true, "R2": true, "R3": true, "R4": true, "R5": true}
+	powerTokenRe := regexp.MustCompile(`^[\d,.]{6,}$`) // power values: 154810946 / 114,721,532
+	punctRe := regexp.MustCompile(`[^\p{L}\d\s\-_.]`)
 
 	// Get existing active members
 	existingMembers := make(map[string]Member)
@@ -6717,29 +6748,74 @@ func importMemberScreenshot(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		matches := rankRe.FindStringSubmatch(line)
-		if matches == nil {
-			continue
-		}
-		rank := "R" + strings.ToUpper(matches[1])
-		if !validRanks[rank] {
-			continue
+		// Rank badge is optional — OCR garbles it often ("Ra", "RS", "4)").
+		// Lines without a readable badge are kept; their rank is resolved
+		// against known members below.
+		rank := ""
+		namePart := line
+		if idx := rankRe.FindStringIndex(line); idx != nil {
+			r := "R" + strings.ToUpper(rankRe.FindStringSubmatch(line)[1])
+			if validRanks[r] {
+				rank = r
+			}
+
+			// Take only the text AFTER the rank badge — everything before it is
+			// the row's rank-number column and left-side UI junk. For layouts
+			// where the name precedes the badge, fall back to the text before it.
+			after := strings.TrimSpace(line[idx[1]:])
+			if after != "" {
+				namePart = after
+			} else {
+				namePart = strings.TrimSpace(line[:idx[0]])
+			}
 		}
 
-		// Remove the rank token and surrounding noise (power numbers, special chars)
-		cleaned := rankRe.ReplaceAllString(line, "")
-		// Remove numbers that look like power (6+ digit sequences with optional commas)
-		cleaned = regexp.MustCompile(`[\d,]{5,}`).ReplaceAllString(cleaned, "")
+		// Drop standalone power values; keep digits attached to words so names
+		// like Sandra1310 stay intact. Standalone small numbers are kept — they
+		// can be part of names ("Alexandros 19", "Ludo 45").
+		var kept []string
+		for _, f := range strings.Fields(namePart) {
+			if powerTokenRe.MatchString(f) {
+				continue
+			}
+			kept = append(kept, f)
+		}
 		// Remove leftover punctuation except letters/digits/spaces/hyphens/underscores/dots
-		cleaned = regexp.MustCompile(`[^\p{L}\d\s\-_.]`).ReplaceAllString(cleaned, " ")
+		cleaned := punctRe.ReplaceAllString(strings.Join(kept, " "), " ")
 		name := strings.Join(strings.Fields(cleaned), " ")
 
-		if len(name) < 2 {
+		if len(name) < 3 {
+			// Shortest real roster name is 4 chars; 1-2 char readings are UI junk.
 			parseErrors = append(parseErrors, fmt.Sprintf("Could not extract name from line: %q", line))
 			continue
 		}
 
 		nameLower := strings.ToLower(name)
+
+		// Resolve against the known roster: an exact match wins, and a close
+		// fuzzy match adopts the canonical name so OCR garble ("PuShKat3")
+		// maps onto the real member ("PuShKal3"). Also fills the rank when
+		// the badge was unreadable.
+		if existing, found := existingMembers[nameLower]; found {
+			name = existing.Name
+			if rank == "" {
+				rank = existing.Rank
+			}
+		} else if best, ok := bestSimilarMember(nameLower, existingMembers); ok {
+			log.Printf("Members OCR: adopting %q as known member %q", name, best.Name)
+			name = best.Name
+			nameLower = strings.ToLower(name)
+			if rank == "" {
+				rank = best.Rank
+			}
+		}
+
+		if rank == "" {
+			// Unreadable badge and unknown member — default so the row still
+			// reaches the review UI; the user fixes the rank there.
+			rank = "R1"
+		}
+
 		if seenNames[nameLower] {
 			continue
 		}
@@ -6805,6 +6881,19 @@ func extractMembersByRows(img image.Image, attrs *ScreenshotAttributes) (string,
 
 	log.Printf("Members OCR: edge detection found %d rows in data region", len(rowBounds))
 
+	client := gosseract.NewClient()
+	defer client.Close()
+
+	rankTokenRe := regexp.MustCompile(`(?i)R[1-5]`)
+
+	// Edge detection can fail on dark UIs and return one giant band. In that
+	// case OCR the whole data region in several preprocessing variants —
+	// tesseract reads multi-line blocks fine and each output line is a row.
+	if len(rowBounds) < 2 {
+		log.Printf("Members OCR: row segmentation failed (%d bands), using whole-region OCR", len(rowBounds))
+		return ocrMembersWholeRegion(img, dataRegion, client), nil
+	}
+
 	var lines []string
 	for i, rb := range rowBounds {
 		rowTop, rowBottom := rb[0], rb[1]
@@ -6819,23 +6908,21 @@ func extractMembersByRows(img image.Image, attrs *ScreenshotAttributes) (string,
 		draw.Draw(rowImg, rowImg.Bounds(), img, image.Point{bounds.Min.X, rowTop}, draw.Src)
 
 		scaled := scaleImage(rowImg, 3)
-		gray := convertToGrayscale(scaled)
+		gray := autoContrast(convertToGrayscale(scaled))
 
-		var buf bytes.Buffer
-		if err := png.Encode(&buf, gray); err != nil {
-			log.Printf("Members row %d: encode failed: %v", i+1, err)
+		text := ocrGrayImage(client, gray, gosseract.PSM_SINGLE_LINE)
+		if text == "" || !rankTokenRe.MatchString(text) {
+			// Second pass on a binarized variant — dark badge backgrounds
+			// often garble the rank token in the raw grayscale pass.
+			if alt := ocrGrayImage(client, binarize(gray, 140), gosseract.PSM_SINGLE_LINE); alt != "" {
+				if text == "" || (rankTokenRe.MatchString(alt) && !rankTokenRe.MatchString(text)) {
+					text = alt
+				}
+			}
+		}
+		if text == "" {
 			continue
 		}
-
-		client := gosseract.NewClient()
-		defer client.Close()
-		client.SetImageFromBytes(buf.Bytes())
-		client.SetPageSegMode(gosseract.PSM_SINGLE_LINE)
-		text, err := client.Text()
-		if err != nil || len(strings.TrimSpace(text)) == 0 {
-			continue
-		}
-		text = strings.TrimSpace(text)
 		log.Printf("Members row %d: %q", i+1, text)
 		lines = append(lines, text)
 	}
@@ -6845,6 +6932,337 @@ func extractMembersByRows(img image.Image, attrs *ScreenshotAttributes) (string,
 	}
 
 	return strings.Join(lines, "\n"), nil
+}
+
+// ocrMembersWholeRegion OCRs the whole data region in several preprocessing
+// variants and fuses the results. Tesseract emits one line per member row;
+// variants disagree on badge/name characters but agree on the power number,
+// so rows are fused by power value. Each fused row is emitted as a synthetic
+// "R{rank} {name}" line that the caller's parser consumes directly.
+func ocrMembersWholeRegion(img image.Image, region *ImageRegion, client *gosseract.Client) string {
+	bounds := img.Bounds()
+	top, bottom := region.Top, region.Bottom
+	if top < bounds.Min.Y {
+		top = bounds.Min.Y
+	}
+	if bottom > bounds.Max.Y {
+		bottom = bounds.Max.Y
+	}
+	if bottom-top < 30 {
+		return ""
+	}
+
+	crop := image.NewRGBA(image.Rect(0, 0, bounds.Dx(), bottom-top))
+	draw.Draw(crop, crop.Bounds(), img, image.Point{bounds.Min.X, top}, draw.Src)
+
+	type variant struct {
+		img *image.Gray
+		psm gosseract.PageSegMode
+	}
+	variants := []variant{
+		{autoContrast(convertToGrayscale(scaleImage(crop, 2))), gosseract.PSM_SINGLE_BLOCK},
+		{binarize(convertToGrayscale(scaleImage(crop, 2)), 140), gosseract.PSM_SINGLE_BLOCK},
+		{autoContrast(convertToGrayscale(scaleImage(crop, 3))), gosseract.PSM_SPARSE_TEXT},
+	}
+
+	rankRe := regexp.MustCompile(`(?i)\bR([1-5])\b`)
+	powerTokenRe := regexp.MustCompile(`^[\d,.]{6,}$`)
+	punctRe := regexp.MustCompile(`[^\p{L}\d\s\-_.]`)
+
+	type fusedRow struct {
+		ranks     []string
+		badged    string // longest badged reading (own power line or dist-1 attached line)
+		powerName string // name from the line carrying this row's own power, no badge
+		attached  string // name from an attached (power-less) line without a badge
+	}
+	rowsByPower := map[string]*fusedRow{}
+	var powerOrder []string
+
+	for i, v := range variants {
+		text := ocrGrayImage(client, v.img, v.psm)
+		if text == "" {
+			continue
+		}
+		log.Printf("Members whole-region OCR variant %d:\n%s\n---", i+1, text)
+
+		type vline struct {
+			text  string
+			power string
+		}
+		var vlines []vline
+		for _, raw := range strings.Split(text, "\n") {
+			line := strings.TrimSpace(raw)
+			if line == "" {
+				continue
+			}
+			// Anchor the row on its power value (first standalone 6+ digit token).
+			power := ""
+			for _, tok := range strings.Fields(line) {
+				if powerTokenRe.MatchString(tok) {
+					power = strings.NewReplacer(",", "", ".", "").Replace(tok)
+					break
+				}
+			}
+			vlines = append(vlines, vline{text: line, power: power})
+		}
+
+		// Variants split one roster row across lines: sparse text reads
+		// name-then-power ("R4 MKJUL" then "94929239") while block reads can
+		// emit power-then-name ("Aa R2| 55443471" then "[R2| tonton nico").
+		// Attach each power-less line to the closest power line (at most 2
+		// lines away). On a distance tie prefer the power line that carries
+		// no name of its own — that row is the one that lost its name in the
+		// split.
+		hasOwnName := func(text string) bool {
+			mm := rankRe.FindStringIndex(text)
+			namePart := text
+			if mm != nil {
+				namePart = text[mm[1]:]
+			}
+			for _, f := range strings.Fields(namePart) {
+				if powerTokenRe.MatchString(f) {
+					continue
+				}
+				if mm == nil && len(punctRe.ReplaceAllString(f, "")) <= 2 {
+					continue
+				}
+				if punctRe.ReplaceAllString(f, "") != "" {
+					return true
+				}
+			}
+			return false
+		}
+		assigned := make([]string, len(vlines))
+		assignedDist := make([]int, len(vlines))
+		for i, vl := range vlines {
+			if vl.power != "" {
+				assigned[i] = vl.power
+				continue
+			}
+			fwdJ, fwdD := -1, 3
+			for j := i + 1; j < len(vlines); j++ {
+				if vlines[j].power == "" {
+					continue
+				}
+				if j-i < fwdD {
+					fwdD, fwdJ = j-i, j
+				}
+			}
+			bwdJ, bwdD := -1, 3
+			for j := i - 1; j >= 0; j-- {
+				if vlines[j].power == "" {
+					continue
+				}
+				if i-j < bwdD {
+					bwdD, bwdJ = i-j, j
+				}
+			}
+			bestJ, bestD := fwdJ, fwdD
+			switch {
+			case fwdJ < 0:
+				bestJ, bestD = bwdJ, bwdD
+			case bwdJ >= 0 && bwdD < fwdD:
+				bestJ, bestD = bwdJ, bwdD
+			case bwdJ >= 0 && bwdD == fwdD:
+				fwdNamed, bwdNamed := hasOwnName(vlines[fwdJ].text), hasOwnName(vlines[bwdJ].text)
+				if fwdNamed && !bwdNamed {
+					bestJ, bestD = bwdJ, bwdD
+				}
+			}
+			if bestJ >= 0 {
+				assigned[i] = vlines[bestJ].power
+				assignedDist[i] = bestD
+			}
+		}
+
+		for i, vl := range vlines {
+			if assigned[i] == "" {
+				continue
+			}
+			row, ok := rowsByPower[assigned[i]]
+			if !ok {
+				row = &fusedRow{}
+				rowsByPower[assigned[i]] = row
+				powerOrder = append(powerOrder, assigned[i])
+			}
+			line := vl.text
+
+			// Rank candidate: clean R1-R5 badge in this variant's reading.
+			m := rankRe.FindStringIndex(line)
+			if m != nil && (vl.power != "" || assignedDist[i] <= 1) {
+				row.ranks = append(row.ranks, "R"+strings.ToUpper(rankRe.FindStringSubmatch(line)[1]))
+			}
+
+			// Name candidate: text after the badge, or all non-power tokens when
+			// the badge was garbled. Rows without a badge still get their name
+			// through; the parser resolves their rank against known members.
+			namePart := line
+			if m != nil {
+				namePart = strings.TrimSpace(line[m[1]:])
+			}
+			var kept []string
+			for _, f := range strings.Fields(namePart) {
+				if powerTokenRe.MatchString(f) {
+					continue
+				}
+				if m == nil && len(punctRe.ReplaceAllString(f, "")) <= 2 {
+					continue // badge/UI junk: short tokens only appear on garbled lines
+				}
+				kept = append(kept, f)
+			}
+			name := strings.Join(strings.Fields(punctRe.ReplaceAllString(strings.Join(kept, " "), " ")), " ")
+			if name == "" {
+				continue
+			}
+			// Badged readings are pooled longest-wins: a clean badge marks a
+			// trustworthy row split, and the longest reading across variants
+			// usually survives garble best (e.g. "MKJUL" vs the same row read
+			// as "mau"). Only dist-1 attached lines join the pool — farther
+			// attachments tend to belong to a different (often pinned) row.
+			own := vl.power != ""
+			switch {
+			case m != nil && (own || assignedDist[i] == 1) && len(name) > len(row.badged):
+				row.badged = name
+			case own && row.powerName == "":
+				row.powerName = name
+			case !own && row.attached == "":
+				row.attached = name
+			}
+		}
+	}
+
+	// Garbage name fragments like "Tr." or "mau" slip through the length
+	// checks; require at least three letters before accepting a reading.
+	lettersOK := func(s string) bool {
+		n := 0
+		for _, r := range s {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				n++
+			}
+		}
+		return n >= 3
+	}
+	var lines []string
+	for _, power := range powerOrder {
+		row := rowsByPower[power]
+		name := ""
+		for _, cand := range []string{row.badged, row.powerName, row.attached} {
+			if lettersOK(cand) {
+				name = cand
+				break
+			}
+		}
+		if name == "" {
+			log.Printf("Members OCR: skipping fused row (power %s): no readable name in any variant", power)
+			continue
+		}
+		// Majority vote across variants for the rank; empty when unreadable.
+		rank := ""
+		counts := map[string]int{}
+		for _, r := range row.ranks {
+			counts[r]++
+			if rank == "" || counts[r] > counts[rank] {
+				rank = r
+			}
+		}
+		if rank == "" {
+			log.Printf("Members OCR: fused row (power %s) name=%q has no readable rank badge", power, name)
+			lines = append(lines, " "+name)
+			continue
+		}
+		lines = append(lines, rank+" "+name)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ocrGrayImage runs tesseract in the given page-segmentation mode on a grayscale image.
+func ocrGrayImage(client *gosseract.Client, gray *image.Gray, psm gosseract.PageSegMode) string {
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, gray); err != nil {
+		return ""
+	}
+	if err := client.SetImageFromBytes(buf.Bytes()); err != nil {
+		return ""
+	}
+	client.SetPageSegMode(psm)
+	text, err := client.Text()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+// binarize thresholds a grayscale image to pure black/white (pixels above
+// threshold stay white, the rest becomes black).
+func binarize(gray *image.Gray, threshold uint8) *image.Gray {
+	out := image.NewGray(gray.Bounds())
+	for y := gray.Rect.Min.Y; y < gray.Rect.Max.Y; y++ {
+		for x := gray.Rect.Min.X; x < gray.Rect.Max.X; x++ {
+			if gray.GrayAt(x, y).Y > threshold {
+				out.SetGray(x, y, color.Gray{Y: 255})
+			}
+		}
+	}
+	return out
+}
+
+// autoContrast stretches the grayscale histogram to the full 0-255 range,
+// clipping the darkest/brightest 1% of pixels. Game UI screenshots are dark
+// and low-contrast; tesseract reads them much better after stretching.
+func autoContrast(gray *image.Gray) *image.Gray {
+	bounds := gray.Bounds()
+	total := bounds.Dx() * bounds.Dy()
+	if total == 0 {
+		return gray
+	}
+
+	hist := make([]int, 256)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			hist[gray.GrayAt(x, y).Y]++
+		}
+	}
+
+	clip := total / 100
+	lo, hi := 0, 255
+	sum := 0
+	for v := 0; v < 256; v++ {
+		sum += hist[v]
+		if sum > clip {
+			lo = v
+			break
+		}
+	}
+	sum = 0
+	for v := 255; v >= 0; v-- {
+		sum += hist[v]
+		if sum > clip {
+			hi = v
+			break
+		}
+	}
+	if hi <= lo {
+		return gray
+	}
+
+	lut := make([]uint8, 256)
+	for v := range lut {
+		nv := (v - lo) * 255 / (hi - lo)
+		if nv < 0 {
+			nv = 0
+		} else if nv > 255 {
+			nv = 255
+		}
+		lut[v] = uint8(nv)
+	}
+
+	out := image.NewGray(bounds)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			out.SetGray(x, y, color.Gray{Y: lut[gray.GrayAt(x, y).Y]})
+		}
+	}
+	return out
 }
 
 // Auto-register a list of player names as R1 members (for unmatched OCR results)
@@ -7548,8 +7966,9 @@ func preprocessImageForOCR(imageData []byte) ([]byte, error) {
 	// Convert to grayscale
 	grayImg := convertToGrayscale(scaledImg)
 
-	// For small images, skip contrast enhancement (can make things worse)
-	processedImg := grayImg
+	// Stretch the histogram — game UI screenshots are dark and low-contrast,
+	// tesseract reads them much better after auto-contrast.
+	processedImg := autoContrast(grayImg)
 
 	// Encode back to bytes
 	var buf bytes.Buffer
@@ -7557,7 +7976,7 @@ func preprocessImageForOCR(imageData []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode processed image: %v", err)
 	}
 
-	log.Printf("Image preprocessed: %dx%d -> %dx%d (2x scaled grayscale)",
+	log.Printf("Image preprocessed: %dx%d -> %dx%d (2x scaled grayscale + auto-contrast)",
 		img.Bounds().Dx(), img.Bounds().Dy(),
 		processedImg.Bounds().Dx(), processedImg.Bounds().Dy())
 

--- a/main.go
+++ b/main.go
@@ -247,6 +247,9 @@ type Settings struct {
 	MarshalGuardEnabled          bool   `json:"marshal_guard_enabled"`
 	DesertStormEnabled           bool   `json:"desert_storm_enabled"`
 	ZombieSiegeEnabled           bool   `json:"zombie_siege_enabled"`
+	DonationWeeklyTarget         int    `json:"donation_weekly_target"`
+	ConductorDonationThreshold   int    `json:"conductor_donation_threshold"`
+	VipDonationThreshold         int    `json:"vip_donation_threshold"`
 }
 
 type MemberRanking struct {
@@ -1907,6 +1910,26 @@ Ask in alliance chat for the train to be assigned. Thanks for keeping the train 
 			return err
 		}
 		log.Println("Database migration: Added zombie_siege_enabled column to settings table")
+	}
+
+	// Migrate settings table to add donation tracking columns if missing
+	for _, col := range []struct {
+		name    string
+		def     string
+		display string
+	}{
+		{"donation_weekly_target", "0", "donation_weekly_target"},
+		{"conductor_donation_threshold", "60000", "conductor_donation_threshold"},
+		{"vip_donation_threshold", "40000", "vip_donation_threshold"},
+	} {
+		var exists bool
+		err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('settings') WHERE name='` + col.name + `'`).Scan(&exists)
+		if err != nil || !exists {
+			if _, err = db.Exec(`ALTER TABLE settings ADD COLUMN ` + col.name + ` INTEGER NOT NULL DEFAULT ` + col.def); err != nil {
+				return err
+			}
+			log.Println("Database migration: Added " + col.display + " column to settings table")
+		}
 	}
 
 	// Create marshal_guard_events table
@@ -4860,7 +4883,10 @@ func getSettings(w http.ResponseWriter, r *http.Request) {
 		COALESCE(vip_seat_enabled, 1) as vip_seat_enabled,
 		COALESCE(marshal_guard_enabled, 1) as marshal_guard_enabled,
 		COALESCE(desert_storm_enabled, 1) as desert_storm_enabled,
-		COALESCE(zombie_siege_enabled, 1) as zombie_siege_enabled
+		COALESCE(zombie_siege_enabled, 1) as zombie_siege_enabled,
+		COALESCE(donation_weekly_target, 0) as donation_weekly_target,
+		COALESCE(conductor_donation_threshold, 60000) as conductor_donation_threshold,
+		COALESCE(vip_donation_threshold, 40000) as vip_donation_threshold
 		FROM settings WHERE id = 1`).Scan(
 		&settings.ID,
 		&settings.AllianceName,
@@ -4888,6 +4914,9 @@ func getSettings(w http.ResponseWriter, r *http.Request) {
 		&settings.MarshalGuardEnabled,
 		&settings.DesertStormEnabled,
 		&settings.ZombieSiegeEnabled,
+		&settings.DonationWeeklyTarget,
+		&settings.ConductorDonationThreshold,
+		&settings.VipDonationThreshold,
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -4941,7 +4970,10 @@ func updateSettings(w http.ResponseWriter, r *http.Request) {
 		vip_seat_enabled = ?,
 		marshal_guard_enabled = ?,
 		desert_storm_enabled = ?,
-		zombie_siege_enabled = ?
+		zombie_siege_enabled = ?,
+		donation_weekly_target = ?,
+		conductor_donation_threshold = ?,
+		vip_donation_threshold = ?
 		WHERE id = 1`,
 		settings.AllianceName,
 		settings.AllianceShortName,
@@ -4968,6 +5000,9 @@ func updateSettings(w http.ResponseWriter, r *http.Request) {
 		settings.MarshalGuardEnabled,
 		settings.DesertStormEnabled,
 		settings.ZombieSiegeEnabled,
+		settings.DonationWeeklyTarget,
+		settings.ConductorDonationThreshold,
+		settings.VipDonationThreshold,
 	)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -5109,10 +5144,13 @@ func luckyDraw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Donation thresholds: conductor = 60k, vip = 40k
-	threshold := int64(40000)
+	// Donation thresholds from settings (defaults: conductor = 60k, vip = 40k)
+	conductorThreshold, vipThreshold := 60000, 40000
+	db.QueryRow(`SELECT COALESCE(conductor_donation_threshold, 60000), COALESCE(vip_donation_threshold, 40000)
+		FROM settings WHERE id = 1`).Scan(&conductorThreshold, &vipThreshold)
+	threshold := int64(vipThreshold)
 	if req.Type == "conductor" {
-		threshold = int64(60000)
+		threshold = int64(conductorThreshold)
 	}
 
 	// Eligible = members with tech donations >= threshold for the given week
@@ -5912,6 +5950,26 @@ func getMemberTimelines(w http.ResponseWriter, r *http.Request) {
 			vsRows.Close()
 		}
 
+		// Get weekly tech donations for this member (keyed by week date)
+		donationWeekMap := make(map[string]int)
+		donationRows, err := db.Query(`
+			SELECT week_date, SUM(amount) as weekly_total
+			FROM tech_donations
+			WHERE member_id = ? AND donation_type = 'weekly' AND week_date >= ?
+			GROUP BY week_date
+			ORDER BY week_date ASC
+		`, member.ID, formatDateString(startDate))
+		if err == nil {
+			for donationRows.Next() {
+				var weekDate string
+				var total int
+				if err := donationRows.Scan(&weekDate, &total); err == nil {
+					donationWeekMap[weekDate] = total
+				}
+			}
+			donationRows.Close()
+		}
+
 		// Build weekly timeline arrays
 		weekLabels := []string{}
 		pointsWithReset := []int{}
@@ -5931,6 +5989,7 @@ func getMemberTimelines(w http.ResponseWriter, r *http.Request) {
 		powerValues := []int{}
 		lastKnownPower := 0
 		vsWeeklyTotals := []int{}
+		donationWeeklyTotals := []int{}
 
 		currentPoints := 0
 		cumulativePoints := 0
@@ -6092,6 +6151,7 @@ func getMemberTimelines(w http.ResponseWriter, r *http.Request) {
 			aboveAvgPenaltyCumulative = append(aboveAvgPenaltyCumulative, cumulativeAboveAvgPenalty)
 			powerValues = append(powerValues, weekMaxPower)
 			vsWeeklyTotals = append(vsWeeklyTotals, vsWeekMap[weekStartStr])
+			donationWeeklyTotals = append(donationWeeklyTotals, donationWeekMap[weekStartStr])
 
 			currentDate = currentDate.AddDate(0, 0, 7)
 		}
@@ -6128,6 +6188,7 @@ func getMemberTimelines(w http.ResponseWriter, r *http.Request) {
 			"conductor_dates":              conductorWeekLabels,
 			"power":                        powerValues,
 			"vs_weekly_total":              vsWeeklyTotals,
+			"donation_weekly_total":        donationWeeklyTotals,
 		}
 	}
 
@@ -16382,6 +16443,114 @@ func processDonationScreenshots(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// getDonationCompliance — GET /api/donations/compliance?weeks=N
+// Weekly donation totals per member vs the configured weekly target.
+func getDonationCompliance(w http.ResponseWriter, r *http.Request) {
+	weeksParam := r.URL.Query().Get("weeks")
+	numWeeks := 4
+	if weeksParam != "" {
+		if n, err := strconv.Atoi(weeksParam); err == nil && n > 0 && n <= 12 {
+			numWeeks = n
+		}
+	}
+
+	var weeklyTarget int
+	db.QueryRow(`SELECT COALESCE(donation_weekly_target, 0) FROM settings WHERE id = 1`).Scan(&weeklyTarget)
+
+	memberRows, err := db.Query(`SELECT id, name, COALESCE(nickname, ''), rank FROM members WHERE deleted_at IS NULL ORDER BY name`)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	type ComplianceMember struct {
+		ID       int
+		Name     string
+		Nickname string
+		Rank     string
+	}
+	var members []ComplianceMember
+	for memberRows.Next() {
+		var m ComplianceMember
+		if err := memberRows.Scan(&m.ID, &m.Name, &m.Nickname, &m.Rank); err != nil {
+			continue
+		}
+		members = append(members, m)
+	}
+	memberRows.Close()
+
+	now := getServerTime()
+	currentMonday := getMondayOfWeek(now)
+	startDate := currentMonday.AddDate(0, 0, -(numWeeks-1)*7)
+
+	// week_date -> member_id -> total amount (only matched members count)
+	donationRows, err := db.Query(`
+		SELECT member_id, week_date, SUM(amount)
+		FROM tech_donations
+		WHERE donation_type = 'weekly' AND member_id IS NOT NULL AND week_date >= ?
+		GROUP BY member_id, week_date
+	`, formatDateString(startDate))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	donationData := make(map[string]map[int]int)
+	for donationRows.Next() {
+		var memberID int
+		var weekDate string
+		var amount int
+		if err := donationRows.Scan(&memberID, &weekDate, &amount); err != nil {
+			continue
+		}
+		if donationData[weekDate] == nil {
+			donationData[weekDate] = make(map[int]int)
+		}
+		donationData[weekDate][memberID] += amount
+	}
+	donationRows.Close()
+
+	type MemberCompliance struct {
+		MemberID int    `json:"member_id"`
+		Name     string `json:"name"`
+		Nickname string `json:"nickname,omitempty"`
+		Rank     string `json:"rank"`
+		Amount   int    `json:"amount"`
+		Met      bool   `json:"met"`
+		HasData  bool   `json:"has_data"`
+	}
+	type WeekCompliance struct {
+		WeekDate  string             `json:"week_date"`
+		WeekLabel string             `json:"week_label"`
+		Members   []MemberCompliance `json:"members"`
+	}
+
+	weeks := make([]WeekCompliance, 0, numWeeks)
+	for i := numWeeks - 1; i >= 0; i-- {
+		monday := currentMonday.AddDate(0, 0, -i*7)
+		sunday := monday.AddDate(0, 0, 6)
+		weekDate := formatDateString(monday)
+		weekLabel := fmt.Sprintf("%s – %s", monday.Format("Jan 2"), sunday.Format("Jan 2"))
+
+		weekDonations := donationData[weekDate]
+		memberList := make([]MemberCompliance, 0, len(members))
+		for _, m := range members {
+			mc := MemberCompliance{MemberID: m.ID, Name: m.Name, Nickname: m.Nickname, Rank: m.Rank}
+			if amount, ok := weekDonations[m.ID]; ok {
+				mc.Amount = amount
+				mc.HasData = true
+				mc.Met = weeklyTarget > 0 && amount >= weeklyTarget
+			}
+			memberList = append(memberList, mc)
+		}
+		weeks = append(weeks, WeekCompliance{WeekDate: weekDate, WeekLabel: weekLabel, Members: memberList})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"target": weeklyTarget,
+		"weeks":  weeks,
+	})
+}
+
 // getDonationRecords — GET /api/donations?type=daily|weekly&date=YYYY-MM-DD
 func getDonationRecords(w http.ResponseWriter, r *http.Request) {
 	donationType := r.URL.Query().Get("type")
@@ -16676,6 +16845,7 @@ func main() {
 	router.HandleFunc("/api/donations", authMiddleware(getDonationRecords)).Methods("GET")
 	router.HandleFunc("/api/donations", authMiddleware(r3PlusMiddleware(saveDonationRecords))).Methods("POST")
 	router.HandleFunc("/api/donations/process-screenshots", authMiddleware(r3PlusMiddleware(processDonationScreenshots))).Methods("POST")
+	router.HandleFunc("/api/donations/compliance", authMiddleware(getDonationCompliance)).Methods("GET")
 	router.HandleFunc("/api/donations/{id}", authMiddleware(r3PlusMiddleware(deleteDonationRecord))).Methods("DELETE")
 
 	// Health check endpoints (no auth)

--- a/static/donations.html
+++ b/static/donations.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tech Donations - Last War Alliance</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="branding.js"></script>
+    <script src="toast.js"></script>
+    <script src="common.js"></script>
+    <script src="navigation.js"></script>
+</head>
+<body data-h1="🧟 Last War: Survival" data-subtitle="Tech donations — who feeds the alliance, who freeloads.">
+    <div class="container">
+
+        <main>
+            <!-- Tab Buttons -->
+            <div class="tab-buttons">
+                <button class="tab-btn active" data-tab="import">📥 Import</button>
+                <button class="tab-btn" data-tab="leaderboard">🏆 Leaderboard</button>
+                <button class="tab-btn" data-tab="compliance">✅ Compliance</button>
+            </div>
+
+            <!-- Import Tab -->
+            <div id="tab-import" class="tab-content active">
+                <section class="form-section">
+                    <div class="mg-toolbar">
+                        <h3>📷 Donation Screenshot Upload</h3>
+                    </div>
+                    <div class="form-group" style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-end;">
+                        <div>
+                            <label for="donation-type-select">Leaderboard Type</label>
+                            <select id="donation-type-select" class="form-control">
+                                <option value="weekly" selected>Weekly</option>
+                                <option value="daily">Daily</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label for="donation-record-date">Record Date (week start)</label>
+                            <input type="date" id="donation-record-date" class="form-control">
+                        </div>
+                    </div>
+                    <input type="file" id="donation-image-input" accept="image/*" multiple style="display:none;">
+                    <div id="donation-drop-zone" class="drop-zone">
+                        <div id="donation-drop-content">
+                            <div class="drop-icon">📁</div>
+                            <p class="drop-text">Tap to upload or drag &amp; drop</p>
+                            <p class="drop-subtext">Strength Ranking → Donation tab screenshots (up to 40 images)</p>
+                        </div>
+                        <div id="donation-preview-container" class="preview-container">
+                            <div class="preview-header">
+                                <p id="donation-files-count"></p>
+                                <button type="button" id="donation-clear-btn" class="btn btn-secondary">🗑️ Clear</button>
+                            </div>
+                            <div id="donation-preview-gallery"></div>
+                        </div>
+                    </div>
+                    <button type="button" id="donation-process-btn" class="btn btn-primary uploader-only" style="display:none;">🔍 Process Screenshots with OCR</button>
+                    <div id="donation-progress-wrap" style="display:none;margin-top:.75rem;">
+                        <div style="display:flex;justify-content:space-between;font-size:.82em;margin-bottom:.3rem;">
+                            <span id="donation-progress-label">Processing…</span>
+                            <span id="donation-progress-time">0s</span>
+                        </div>
+                        <div style="background:var(--bg-secondary,#e5e7eb);border-radius:999px;height:8px;overflow:hidden;">
+                            <div id="donation-progress-bar" style="height:100%;width:0%;background:var(--primary,#6366f1);border-radius:999px;transition:width .3s ease;"></div>
+                        </div>
+                    </div>
+                    <p class="help-text" style="margin-top:.75rem;">
+                        💡 Manual entry is available from the Leaderboard tab (➕ Add Record).
+                    </p>
+                </section>
+            </div>
+
+            <!-- Leaderboard Tab -->
+            <div id="tab-leaderboard" class="tab-content">
+                <section class="form-section">
+                    <div class="mg-toolbar">
+                        <h3>🏆 Donation Records</h3>
+                        <div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;">
+                            <select id="board-type-select" class="form-control">
+                                <option value="weekly" selected>Weekly</option>
+                                <option value="daily">Daily</option>
+                            </select>
+                            <input type="date" id="board-date" class="form-control">
+                            <button type="button" id="add-record-btn" class="primary-btn uploader-only" style="display:none;">➕ Add Record</button>
+                        </div>
+                    </div>
+                    <div id="board-list" class="rk-table-wrapper">
+                        <p class="loading">⏳ Loading records...</p>
+                    </div>
+                </section>
+            </div>
+
+            <!-- Compliance Tab -->
+            <div id="tab-compliance" class="tab-content">
+                <section class="form-section">
+                    <div class="mg-toolbar">
+                        <h3>✅ Weekly Donation Compliance</h3>
+                        <select id="compliance-weeks" class="form-control">
+                            <option value="2">2 weeks</option>
+                            <option value="4" selected>4 weeks</option>
+                            <option value="8">8 weeks</option>
+                            <option value="12">12 weeks</option>
+                        </select>
+                    </div>
+                    <div id="compliance-list">
+                        <p class="loading">⏳ Loading compliance...</p>
+                    </div>
+                </section>
+            </div>
+        </main>
+
+    </div>
+
+    <!-- OCR Preview Modal -->
+    <div id="donation-ocr-modal" class="modal" style="display:none;">
+        <div class="modal-content" style="max-width:860px;">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3>📋 OCR Preview — Review &amp; Import</h3>
+            <p class="text-muted" style="margin-top:0;font-size:0.9em;">
+                Edit any cell before importing. Records replace existing data for the selected type + date.
+            </p>
+            <div id="donation-ocr-content"></div>
+            <div class="modal-footer" style="margin-top:1rem;">
+                <button type="button" id="donation-ocr-cancel-btn" class="secondary-btn">Cancel</button>
+                <button type="button" id="donation-ocr-import-btn" class="primary-btn">✔ Import Records</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Add Record Modal -->
+    <div id="add-record-modal" class="modal" style="display:none;">
+        <div class="modal-content" style="max-width:440px;">
+            <span class="close" role="button" tabindex="0" aria-label="Close dialog">&times;</span>
+            <h3>➕ Add Donation Record</h3>
+            <form id="add-record-form">
+                <div class="form-group">
+                    <label for="record-member">Member</label>
+                    <select id="record-member" class="form-control" required></select>
+                </div>
+                <div class="form-group">
+                    <label for="record-amount">Donation Amount</label>
+                    <input type="number" id="record-amount" class="form-control" min="0" required placeholder="e.g. 45000">
+                </div>
+                <button type="submit" class="btn btn-primary">💾 Save Record</button>
+            </form>
+        </div>
+    </div>
+
+    <script src="theme.js"></script>
+    <script src="donations.js"></script>
+</body>
+</html>

--- a/static/donations.js
+++ b/static/donations.js
@@ -1,0 +1,565 @@
+// Tech Donations page logic
+let canUpload = false; // R3, R4, R5, admin — can upload screenshots & manage records
+let isOfficer = false; // R4, R5, admin — can delete records
+let isAdmin = false;
+let selectedFiles = [];
+let ocrPreview = null; // { donation_type, record_date, rows: [...] }
+let allMembers = [];
+
+async function checkAuth() {
+    try {
+        const res = await fetch('/api/check-auth');
+        const data = await res.json();
+        if (!data.authenticated) { window.location.href = '/login.html'; return false; }
+        if (data.must_change_password) { window.location.href = '/profile.html?must_change_password=1'; return false; }
+
+        let display = `👤 ${data.username}`;
+        if (data.rank) display += ` (${data.rank})`;
+        const usernameDisplay = document.getElementById('username-display');
+        if (usernameDisplay) {
+            usernameDisplay.textContent = display;
+            usernameDisplay.addEventListener('click', toggleUserDropdown);
+        }
+
+        const logoutBtn = document.getElementById('dropdown-logout-btn');
+        if (logoutBtn) logoutBtn.addEventListener('click', handleLogout);
+
+        document.addEventListener('click', (event) => {
+            const dropdown = document.getElementById('user-dropdown-menu');
+            const btn = document.getElementById('username-display');
+            if (dropdown && btn && !btn.contains(event.target) && !dropdown.contains(event.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
+
+        isAdmin = data.is_admin || false;
+        const rank = (data.rank || '').toUpperCase();
+        canUpload = isAdmin || rank === 'R3' || rank === 'R4' || rank === 'R5';
+        isOfficer = isAdmin || rank === 'R4' || rank === 'R5';
+
+        if (canUpload) {
+            document.querySelectorAll('.uploader-only').forEach(el => el.style.display = '');
+        }
+        if (isAdmin) {
+            const adminLink = document.getElementById('admin-nav-link');
+            const gyLink = document.getElementById('graveyard-nav-link');
+            if (adminLink) adminLink.style.display = 'block';
+            if (gyLink) gyLink.style.display = 'block';
+        }
+        return true;
+    } catch { return false; }
+}
+
+// ---- Tab switching ----
+function initTabs() {
+    document.querySelectorAll('.tab-btn[data-tab]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.tab-btn[data-tab]').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+            btn.classList.add('active');
+            const tab = document.getElementById('tab-' + btn.dataset.tab);
+            if (tab) tab.classList.add('active');
+            if (btn.dataset.tab === 'leaderboard') loadBoard();
+            if (btn.dataset.tab === 'compliance') loadCompliance();
+        });
+    });
+}
+
+// ---- Upload ----
+function initUpload() {
+    const dropZone = document.getElementById('donation-drop-zone');
+    const fileInput = document.getElementById('donation-image-input');
+    const processBtn = document.getElementById('donation-process-btn');
+    const clearBtn = document.getElementById('donation-clear-btn');
+
+    dropZone.addEventListener('click', (e) => {
+        if (e.target.closest('button')) return;
+        fileInput.click();
+    });
+    dropZone.addEventListener('dragover', (e) => { e.preventDefault(); dropZone.classList.add('dragover'); });
+    dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+    dropZone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        dropZone.classList.remove('dragover');
+        handleFiles(e.dataTransfer.files);
+    });
+    fileInput.addEventListener('change', () => handleFiles(fileInput.files));
+    clearBtn.addEventListener('click', clearFiles);
+    processBtn.addEventListener('click', processScreenshots);
+}
+
+function handleFiles(fileList) {
+    const files = Array.from(fileList).filter(f => f.type.startsWith('image/'));
+    if (files.length === 0) return;
+    selectedFiles = selectedFiles.concat(files).slice(0, 40);
+    renderFilePreview();
+}
+
+function renderFilePreview() {
+    const gallery = document.getElementById('donation-preview-gallery');
+    const container = document.getElementById('donation-preview-container');
+    const dropContent = document.getElementById('donation-drop-content');
+    const processBtn = document.getElementById('donation-process-btn');
+    const countEl = document.getElementById('donation-files-count');
+
+    if (selectedFiles.length === 0) {
+        container.style.display = 'none';
+        dropContent.style.display = '';
+        if (canUpload) processBtn.style.display = 'none';
+        return;
+    }
+
+    dropContent.style.display = 'none';
+    container.style.display = 'block';
+    if (canUpload) processBtn.style.display = 'block';
+    countEl.textContent = `${selectedFiles.length} file${selectedFiles.length > 1 ? 's' : ''} selected`;
+
+    gallery.innerHTML = '';
+    selectedFiles.forEach((file, i) => {
+        const div = document.createElement('div');
+        div.className = 'preview-item';
+        const img = document.createElement('img');
+        img.className = 'preview-img';
+        img.src = URL.createObjectURL(file);
+        const removeBtn = document.createElement('button');
+        removeBtn.className = 'remove-file';
+        removeBtn.textContent = '×';
+        removeBtn.onclick = (e) => { e.stopPropagation(); selectedFiles.splice(i, 1); renderFilePreview(); };
+        const nameEl = document.createElement('div');
+        nameEl.className = 'file-name';
+        nameEl.textContent = file.name;
+        div.append(img, removeBtn, nameEl);
+        gallery.appendChild(div);
+    });
+}
+
+function clearFiles() {
+    selectedFiles = [];
+    document.getElementById('donation-image-input').value = '';
+    renderFilePreview();
+}
+
+async function processScreenshots() {
+    if (selectedFiles.length === 0) return;
+    const donationType = document.getElementById('donation-type-select').value;
+    const recordDate = document.getElementById('donation-record-date').value;
+    if (!recordDate) { showToast('Select the record date first', 'warning'); return; }
+
+    const formData = new FormData();
+    formData.append('donation_type', donationType);
+    formData.append('record_date', recordDate);
+    selectedFiles.forEach(f => formData.append('images', f));
+
+    const progressWrap = document.getElementById('donation-progress-wrap');
+    const progressBar = document.getElementById('donation-progress-bar');
+    const progressLabel = document.getElementById('donation-progress-label');
+    const progressTime = document.getElementById('donation-progress-time');
+    const processBtn = document.getElementById('donation-process-btn');
+    processBtn.disabled = true;
+    progressWrap.style.display = 'block';
+    progressBar.style.width = '15%';
+    progressLabel.textContent = 'Processing screenshots with OCR…';
+    const started = Date.now();
+    const timer = setInterval(() => {
+        progressTime.textContent = Math.floor((Date.now() - started) / 1000) + 's';
+        const w = Math.min(90, 15 + (Date.now() - started) / 200);
+        progressBar.style.width = w + '%';
+    }, 500);
+
+    try {
+        const res = await fetch('/api/donations/process-screenshots', { method: 'POST', body: formData });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.message || 'OCR processing failed');
+        progressBar.style.width = '100%';
+        progressLabel.textContent = 'Done';
+        if (!data.entries || data.entries.length === 0) {
+            showToast('No rows detected in the screenshots', 'warning');
+            return;
+        }
+        showPreview(data);
+    } catch (e) {
+        showToast('OCR failed: ' + e.message, 'error');
+    } finally {
+        clearInterval(timer);
+        processBtn.disabled = false;
+        setTimeout(() => { progressWrap.style.display = 'none'; progressBar.style.width = '0%'; }, 800);
+    }
+}
+
+// ---- Members ----
+async function loadMembers() {
+    try {
+        const res = await fetch('/api/members');
+        if (!res.ok) return;
+        const data = await res.json();
+        allMembers = (data || []).sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+    } catch { /* non-critical */ }
+}
+
+function buildMemberOptions(memberId) {
+    let opts = '<option value="">— Unmatched —</option>';
+    for (const m of allMembers) {
+        const nick = m.nickname ? ` [${m.nickname}]` : '';
+        const sel = m.id === memberId ? ' selected' : '';
+        opts += `<option value="${m.id}"${sel}>${escapeHtml(m.name)}${escapeHtml(nick)} (${escapeHtml(m.rank)})</option>`;
+    }
+    return opts;
+}
+
+// ---- OCR preview ----
+async function showPreview(result) {
+    ocrPreview = {
+        donation_type: result.donation_type || 'weekly',
+        record_date: result.record_date || '',
+        rows: (result.entries || []).map(e => ({
+            rank_in_snapshot: e.rank_in_snapshot || 0,
+            name_snapshot: e.name_snapshot || '',
+            points: e.points || 0,
+            member_id: e.member_id || null,
+            member_name: e.member_name || '',
+            match_confidence: e.match_confidence || 0,
+            match_type: e.match_type || 'none',
+            points_crop_b64: e.points_crop_b64 || '',
+            name_crop_b64: e.name_crop_b64 || '',
+        })),
+    };
+
+    // Detect existing records for the same type+date (import will overwrite).
+    ocrPreview.existing_count = 0;
+    try {
+        const res = await fetch(`/api/donations?type=${ocrPreview.donation_type}&date=${ocrPreview.record_date}`);
+        if (res.ok) {
+            const existing = await res.json();
+            ocrPreview.existing_count = (existing || []).length;
+        }
+    } catch { /* non-critical */ }
+
+    renderPreview();
+    document.getElementById('donation-ocr-modal').style.display = 'flex';
+}
+
+function matchBadge(row) {
+    const labels = { exact: '✓ exact', nickname: '✓ nickname', fuzzy: '~ fuzzy', none: '✗ none' };
+    const colors = { exact: '#22c55e', nickname: '#22c55e', fuzzy: '#f59e0b', none: '#ef4444' };
+    const t = row.match_type || 'none';
+    return `<span class="match-badge" style="color:${colors[t]};font-size:.78em;" title="Match confidence: ${row.match_confidence}%">${labels[t]}</span>`;
+}
+
+function renderPreview() {
+    const container = document.getElementById('donation-ocr-content');
+    const overwrite = ocrPreview.existing_count > 0
+        ? `<div class="info-banner info-banner--warning" style="margin-bottom:.5rem;">
+               <div class="info-content"><div class="info-icon">⚠️</div>
+               <div class="info-text">${ocrPreview.existing_count} existing record(s) for this type + date will be replaced.</div>
+               </div></div>`
+        : '';
+
+    let rows = '';
+    ocrPreview.rows.forEach((row, rIdx) => {
+        const needsReview = row.points === 0 || row.match_type === 'none' || row.match_type === 'fuzzy';
+        const cls = needsReview ? ' class="zs-warn-row"' : '';
+        const cropThumb = row.points_crop_b64
+            ? `<img src="data:image/png;base64,${row.points_crop_b64}" alt="points crop" style="height:22px;vertical-align:middle;border-radius:3px;margin-left:4px;" title="OCR crop — verify value">`
+            : '';
+        rows += `<tr${cls}>
+            <td class="mg-rank-col">${row.rank_in_snapshot || '—'}</td>
+            <td class="mg-name-col">
+                <input class="mg-cell-input" data-field="name_snapshot" data-row="${rIdx}"
+                    value="${escapeAttr(row.name_snapshot)}" placeholder="Player name">
+                ${matchBadge(row)}
+            </td>
+            <td class="mg-dmg-col">
+                <input class="mg-cell-input" data-field="points" data-row="${rIdx}"
+                    value="${escapeAttr(String(row.points))}" placeholder="0" style="width:130px;">
+                ${cropThumb}
+            </td>
+            <td class="mg-name-col">
+                <select class="mg-member-select" data-row="${rIdx}">${buildMemberOptions(row.member_id)}</select>
+            </td>
+        </tr>`;
+    });
+
+    container.innerHTML = `
+        <div class="mg-v2-card-header">
+            <div class="mg-card-meta">
+                <strong class="mg-event-date">💰 ${ocrPreview.donation_type === 'daily' ? 'Daily' : 'Weekly'} donations — ${escapeHtml(ocrPreview.record_date)}</strong>
+            </div>
+        </div>
+        ${overwrite}
+        <div class="rk-table-wrapper" style="max-height:420px;overflow-y:auto;">
+            <table class="rk-table">
+                <thead><tr><th class="mg-rank-col">#</th><th>Player</th><th class="mg-dmg-col">Points</th><th>Member</th></tr></thead>
+                <tbody>${rows}</tbody>
+            </table>
+        </div>`;
+}
+
+// Sync inline edits back into ocrPreview live data.
+document.addEventListener('input', e => {
+    const t = e.target;
+    if (t.classList.contains('mg-cell-input') && ocrPreview) {
+        const rIdx = parseInt(t.dataset.row);
+        const field = t.dataset.field;
+        if (!isNaN(rIdx)) {
+            if (field === 'points') {
+                ocrPreview.rows[rIdx].points = parseInt(t.value) || 0;
+            } else {
+                ocrPreview.rows[rIdx][field] = t.value;
+            }
+        }
+    }
+});
+
+document.addEventListener('change', e => {
+    const t = e.target;
+    if (t.classList.contains('mg-member-select') && ocrPreview) {
+        const rIdx = parseInt(t.dataset.row);
+        if (!isNaN(rIdx)) {
+            ocrPreview.rows[rIdx].member_id = t.value ? parseInt(t.value) : null;
+        }
+    }
+});
+
+async function importRecords() {
+    if (!ocrPreview) return;
+    const entries = ocrPreview.rows
+        .filter(r => (r.name_snapshot || '').trim() !== '')
+        .map((r, i) => ({
+            rank_in_snapshot: r.rank_in_snapshot || i + 1,
+            name_snapshot: (r.name_snapshot || '').trim(),
+            points: r.points || 0,
+            member_id: r.member_id || null,
+        }));
+    if (entries.length === 0) { showToast('No rows to import', 'warning'); return; }
+
+    const btn = document.getElementById('donation-ocr-import-btn');
+    try {
+        if (btn) { btn.disabled = true; btn.textContent = '⏳ Importing…'; }
+        const res = await fetch('/api/donations', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                donation_type: ocrPreview.donation_type,
+                record_date: ocrPreview.record_date,
+                entries,
+            }),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.message || 'Import failed');
+        showToast(`Imported ${data.saved} donation record(s)`, 'success');
+        document.getElementById('donation-ocr-modal').style.display = 'none';
+        ocrPreview = null;
+        clearFiles();
+        // Refresh leaderboard with the imported data.
+        document.getElementById('board-type-select').value = document.getElementById('donation-type-select').value;
+        document.getElementById('board-date').value = document.getElementById('donation-record-date').value;
+        loadBoard();
+    } catch (e) {
+        showToast('Import failed: ' + e.message, 'error');
+    } finally {
+        if (btn) { btn.disabled = false; btn.textContent = '✔ Import Records'; }
+    }
+}
+
+// ---- Leaderboard ----
+async function loadBoard() {
+    const type = document.getElementById('board-type-select').value;
+    const date = document.getElementById('board-date').value;
+    const list = document.getElementById('board-list');
+    list.innerHTML = '<p class="loading">⏳ Loading records...</p>';
+    try {
+        const res = await fetch(`/api/donations?type=${type}&date=${date}`);
+        if (!res.ok) throw new Error('Failed to load records');
+        const records = await res.json();
+        renderBoard(records || [], type, date);
+    } catch (e) {
+        list.innerHTML = `<p class="error-message">${escapeHtml(e.message)}</p>`;
+    }
+}
+
+function renderBoard(records, type, date) {
+    const list = document.getElementById('board-list');
+    if (!records.length) {
+        list.innerHTML = `<p class="no-data">No ${type} donation records for ${escapeHtml(date)}. Upload screenshots or add records manually.</p>`;
+        return;
+    }
+    const total = records.reduce((s, r) => s + r.amount, 0);
+    let rows = '';
+    records.forEach((r, i) => {
+        const displayName = r.member_id
+            ? `${escapeHtml(r.member_name || r.name_snapshot)}`
+            : `${escapeHtml(r.name_snapshot)} <span class="text-muted" style="font-size:.8em;">(unmatched)</span>`;
+        const deleteBtn = canUpload
+            ? `<button class="secondary-btn donation-delete-btn" data-id="${r.id}" title="Delete record" style="padding:2px 8px;">🗑️</button>`
+            : '';
+        rows += `<tr>
+            <td class="mg-rank-col">${i + 1}</td>
+            <td>${displayName}${r.member_rank ? ` <span class="text-muted" style="font-size:.8em;">(${escapeHtml(r.member_rank)})</span>` : ''}</td>
+            <td class="mg-dmg-col"><strong>${r.amount.toLocaleString()}</strong></td>
+            <td class="mg-rank-col">${deleteBtn}</td>
+        </tr>`;
+    });
+    list.innerHTML = `
+        <p class="text-muted" style="font-size:.85em;margin:.25rem 0 .5rem;">${records.length} record(s) — total: <strong>${total.toLocaleString()}</strong></p>
+        <table class="rk-table">
+            <thead><tr><th class="mg-rank-col">#</th><th>Member</th><th class="mg-dmg-col">Amount</th><th></th></tr></thead>
+            <tbody>${rows}</tbody>
+        </table>`;
+
+    list.querySelectorAll('.donation-delete-btn').forEach(btn => {
+        btn.addEventListener('click', () => deleteRecord(btn.dataset.id));
+    });
+}
+
+async function deleteRecord(id) {
+    if (!confirm('Delete this donation record?')) return;
+    try {
+        const res = await fetch(`/api/donations/${id}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error('Delete failed');
+        showToast('Record deleted', 'success');
+        loadBoard();
+    } catch (e) {
+        showToast(e.message, 'error');
+    }
+}
+
+// ---- Add record modal ----
+function openAddRecordModal() {
+    const sel = document.getElementById('record-member');
+    sel.innerHTML = buildMemberOptions(null).replace('<option value="">— Unmatched —</option>', '<option value="">— Select member —</option>');
+    document.getElementById('record-amount').value = '';
+    document.getElementById('add-record-modal').style.display = 'flex';
+}
+
+async function submitAddRecord(e) {
+    e.preventDefault();
+    const memberId = document.getElementById('record-member').value;
+    const amount = parseInt(document.getElementById('record-amount').value) || 0;
+    if (!memberId) { showToast('Select a member', 'warning'); return; }
+    if (amount <= 0) { showToast('Amount must be positive', 'warning'); return; }
+
+    const type = document.getElementById('board-type-select').value;
+    const date = document.getElementById('board-date').value;
+    const member = allMembers.find(m => m.id === parseInt(memberId));
+
+    try {
+        // Replace-semantics API: fetch existing records, append, save all.
+        const res = await fetch(`/api/donations?type=${type}&date=${date}`);
+        const existing = res.ok ? await res.json() : [];
+        const entries = (existing || []).map(r => ({
+            rank_in_snapshot: r.rank_in_snapshot,
+            name_snapshot: r.name_snapshot || r.member_name,
+            points: r.amount,
+            member_id: r.member_id || null,
+        }));
+        entries.push({
+            rank_in_snapshot: entries.length + 1,
+            name_snapshot: member ? member.name : 'Unknown',
+            points: amount,
+            member_id: parseInt(memberId),
+        });
+        const saveRes = await fetch('/api/donations', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ donation_type: type, record_date: date, entries }),
+        });
+        if (!saveRes.ok) throw new Error('Save failed');
+        showToast('Record added', 'success');
+        document.getElementById('add-record-modal').style.display = 'none';
+        loadBoard();
+    } catch (err) {
+        showToast('Failed to add record: ' + err.message, 'error');
+    }
+}
+
+// ---- Compliance ----
+async function loadCompliance() {
+    const weeks = document.getElementById('compliance-weeks').value;
+    const list = document.getElementById('compliance-list');
+    list.innerHTML = '<p class="loading">⏳ Loading compliance...</p>';
+    try {
+        const res = await fetch(`/api/donations/compliance?weeks=${weeks}`);
+        if (!res.ok) throw new Error('Failed to load compliance');
+        const data = await res.json();
+        renderCompliance(data);
+    } catch (e) {
+        list.innerHTML = `<p class="error-message">${escapeHtml(e.message)}</p>`;
+    }
+}
+
+function renderCompliance(data) {
+    const list = document.getElementById('compliance-list');
+    const target = data.target || 0;
+    const banner = target > 0
+        ? `<p class="text-muted" style="font-size:.85em;">Weekly target: <strong>${target.toLocaleString()}</strong> — <span style="color:#22c55e;">■ met</span> <span style="color:#f59e0b;">■ below</span> <span style="color:#ef4444;">■ no data</span></p>`
+        : `<div class="info-banner" style="margin-bottom:.75rem;"><div class="info-content"><div class="info-icon">ℹ️</div>
+           <div class="info-text">No weekly donation target set — configure it in Settings → Tech Donation Targets.</div></div></div>`;
+
+    let html = banner;
+    (data.weeks || []).forEach(week => {
+        let rows = '';
+        week.members.forEach(m => {
+            let status, color;
+            if (!m.has_data) { status = '—'; color = target > 0 ? '#ef4444' : '#9ca3af'; }
+            else if (target > 0 && m.met) { status = '✔ met'; color = '#22c55e'; }
+            else if (target > 0) { status = 'below'; color = '#f59e0b'; }
+            else { status = '✔'; color = '#22c55e'; }
+            rows += `<tr>
+                <td>${escapeHtml(m.name)}${m.nickname ? ` <span class="text-muted" style="font-size:.8em;">[${escapeHtml(m.nickname)}]</span>` : ''}</td>
+                <td class="mg-rank-col">${escapeHtml(m.rank)}</td>
+                <td class="mg-dmg-col">${m.has_data ? m.amount.toLocaleString() : '—'}</td>
+                <td style="color:${color};font-weight:600;">${status}</td>
+            </tr>`;
+        });
+        html += `
+            <div class="form-section" style="margin-bottom:1rem;">
+                <h4>📅 ${escapeHtml(week.week_label)}</h4>
+                <div class="rk-table-wrapper">
+                    <table class="rk-table">
+                        <thead><tr><th>Member</th><th class="mg-rank-col">Rank</th><th class="mg-dmg-col">Donated</th><th>Status</th></tr></thead>
+                        <tbody>${rows}</tbody>
+                    </table>
+                </div>
+            </div>`;
+    });
+    list.innerHTML = html;
+}
+
+// ---- Modals ----
+function initModals() {
+    document.querySelectorAll('.modal .close').forEach(btn => {
+        btn.addEventListener('click', () => btn.closest('.modal').style.display = 'none');
+        btn.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') btn.closest('.modal').style.display = 'none'; });
+    });
+    document.querySelectorAll('.modal').forEach(modal => {
+        modal.addEventListener('click', (e) => { if (e.target === modal) modal.style.display = 'none'; });
+    });
+    document.getElementById('donation-ocr-cancel-btn').addEventListener('click', () => {
+        document.getElementById('donation-ocr-modal').style.display = 'none';
+    });
+    document.getElementById('donation-ocr-import-btn').addEventListener('click', importRecords);
+    document.getElementById('add-record-btn').addEventListener('click', openAddRecordModal);
+    document.getElementById('add-record-form').addEventListener('submit', submitAddRecord);
+    document.getElementById('board-type-select').addEventListener('change', loadBoard);
+    document.getElementById('board-date').addEventListener('change', loadBoard);
+    document.getElementById('compliance-weeks').addEventListener('change', loadCompliance);
+}
+
+function escapeAttr(str) {
+    return String(str ?? '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// ---- Init ----
+document.addEventListener('DOMContentLoaded', async () => {
+    const ok = await checkAuth();
+    if (!ok) return;
+
+    const today = new Date().toISOString().slice(0, 10);
+    document.getElementById('donation-record-date').value = today;
+    document.getElementById('board-date').value = today;
+
+    initTabs();
+    initUpload();
+    initModals();
+    await loadMembers();
+});

--- a/static/navigation.js
+++ b/static/navigation.js
@@ -55,6 +55,7 @@
                 <a href="/zombie-siege.html" class="nav-link" id="zs-nav-link">🧟 Zombie Siege</a>
                 <a href="/vs.html" class="nav-link">⚔️ VS Points</a>
                 <a href="/vs-compliance.html" class="nav-link">✅ VS Compliance</a>
+                <a href="/donations.html" class="nav-link">💰 Donations</a>
                 <a href="/participation.html" class="nav-link">📋 Participation</a>
                 <a href="/upload.html" class="nav-link">📸 Upload</a>
                 <a href="/settings.html" class="nav-link">⚙️ Settings</a>

--- a/static/rankings.js
+++ b/static/rankings.js
@@ -263,6 +263,7 @@ function buildDetailContent(r) {
                 <label><input type="checkbox" class="timeline-opt" id="show-reset-${r.member.id}" data-member-id="${r.member.id}" checked> Points</label>
                 <label><input type="checkbox" class="timeline-opt" id="show-vs-${r.member.id}" data-member-id="${r.member.id}" checked> VS Points</label>
                 <label><input type="checkbox" class="timeline-opt" id="show-power-${r.member.id}" data-member-id="${r.member.id}"> Power</label>
+                <label><input type="checkbox" class="timeline-opt" id="show-donations-${r.member.id}" data-member-id="${r.member.id}"> Donations</label>
                 <button class="rk-advanced-btn" onclick="toggleAdvanced(${r.member.id}, this)">More ▸</button>
             </div>
             <div class="rk-timeline-advanced" id="advanced-${r.member.id}">
@@ -275,6 +276,7 @@ function buildDetailContent(r) {
             <canvas id="timeline-${r.member.id}" class="member-timeline-canvas" style="display:none"></canvas>
             <canvas id="vs-timeline-${r.member.id}" class="rk-power-canvas" style="display:none"></canvas>
             <canvas id="power-timeline-${r.member.id}" class="rk-power-canvas" style="display:none"></canvas>
+            <canvas id="donation-timeline-${r.member.id}" class="rk-power-canvas" style="display:none"></canvas>
         </div>`;
 
     return `
@@ -476,6 +478,7 @@ function buildMemberChart(ranking, timelineData) {
     const canvas      = document.getElementById(`timeline-${ranking.member.id}`);
     const vsCanvas    = document.getElementById(`vs-timeline-${ranking.member.id}`);
     const powerCanvas = document.getElementById(`power-timeline-${ranking.member.id}`);
+    const donationCanvas = document.getElementById(`donation-timeline-${ranking.member.id}`);
 
     if (!memberData || memberData.dates.length === 0) {
         if (loadingEl) loadingEl.innerHTML = '<p class="empty">No timeline data available.</p>';
@@ -487,7 +490,7 @@ function buildMemberChart(ranking, timelineData) {
     canvas.style.display = '';
 
     // Destroy previous instances
-    [canvas, vsCanvas, powerCanvas].forEach(c => {
+    [canvas, vsCanvas, powerCanvas, donationCanvas].forEach(c => {
         if (!c) return;
         const existing = Chart.getChart(c);
         if (existing) existing.destroy();
@@ -499,6 +502,7 @@ function buildMemberChart(ranking, timelineData) {
     const showBreakdown = document.getElementById(`show-breakdown-${ranking.member.id}`)?.checked ?? false;
     const showVS        = document.getElementById(`show-vs-${ranking.member.id}`)?.checked ?? true;
     const showPower     = document.getElementById(`show-power-${ranking.member.id}`)?.checked ?? false;
+    const showDonations = document.getElementById(`show-donations-${ranking.member.id}`)?.checked ?? false;
     const scaleType     = document.querySelector(`input[name="scale-type-${ranking.member.id}"]:checked`)?.value || 'linear';
 
     applyChartTheme();
@@ -705,6 +709,70 @@ function buildMemberChart(ranking, timelineData) {
             memberTimelineCharts.push(powerChart);
         } else {
             powerCanvas.style.display = 'none';
+        }
+    }
+
+    // ── Donations mini-chart ─────────────────────────────────────────────────
+    if (donationCanvas) {
+        const hasDonations = memberData.donation_weekly_total && memberData.donation_weekly_total.some(v => v > 0);
+        if (showDonations && hasDonations) {
+            donationCanvas.style.display = '';
+            const donationTarget = currentData?.settings?.donation_weekly_target || 0;
+            const donationAnnotations = {};
+            if (donationTarget > 0) {
+                donationAnnotations.target = {
+                    type: 'line', yMin: donationTarget, yMax: donationTarget,
+                    borderColor: 'rgba(239,68,68,0.7)', borderWidth: 1.5, borderDash: [4, 4],
+                    label: { display: true, content: `Target: ${donationTarget.toLocaleString()}`, position: 'end', font: { size: 10 } }
+                };
+            }
+            const donationChart = new Chart(donationCanvas, {
+                type: 'bar',
+                data: {
+                    labels: memberData.dates,
+                    datasets: [{
+                        label: 'Tech Donations',
+                        data: memberData.donation_weekly_total,
+                        backgroundColor: memberData.donation_weekly_total.map(v =>
+                            donationTarget > 0
+                                ? (v >= donationTarget ? 'rgba(34,197,94,0.55)' : 'rgba(239,68,68,0.45)')
+                                : 'rgba(245,158,11,0.55)'
+                        ),
+                        borderColor: memberData.donation_weekly_total.map(v =>
+                            donationTarget > 0
+                                ? (v >= donationTarget ? '#22c55e' : '#ef4444')
+                                : '#f59e0b'
+                        ),
+                        borderWidth: 1,
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                title: items => items[0]?.label || '',
+                                label: item => ` Donations: ${item.parsed.y.toLocaleString()}${donationTarget > 0 ? ' / ' + donationTarget.toLocaleString() + ' target' : ''}`
+                            }
+                        },
+                        annotation: { annotations: donationAnnotations }
+                    },
+                    scales: {
+                        x: { ticks: { maxRotation: 45, minRotation: 45, font: { size: 9 } } },
+                        y: {
+                            beginAtZero: true,
+                            title: { display: true, text: 'Donations', font: { size: 11 } },
+                            ticks: { font: { size: 10 }, callback: v => v >= 1000 ? (v / 1000).toFixed(0) + 'K' : v }
+                        }
+                    },
+                    interaction: { mode: 'nearest', axis: 'x', intersect: false }
+                }
+            });
+            memberTimelineCharts.push(donationChart);
+        } else {
+            donationCanvas.style.display = 'none';
         }
     }
 }

--- a/static/settings.html
+++ b/static/settings.html
@@ -113,6 +113,25 @@
                     </div>
 
                     <div class="settings-group">
+                        <h4>💰 Tech Donation Targets</h4>
+                        <div class="form-group">
+                            <label for="donation-weekly-target">Weekly Donation Target (per member):</label>
+                            <input type="number" id="donation-weekly-target" min="0" placeholder="0 = disabled">
+                            <span class="help-text">Minimum weekly tech donations expected per member. Drives the donations compliance view. Set to 0 to disable.</span>
+                        </div>
+                        <div class="form-group">
+                            <label for="conductor-donation-threshold">Conductor Donation Threshold:</label>
+                            <input type="number" id="conductor-donation-threshold" min="0" required>
+                            <span class="help-text">Minimum weekly tech donations to enter the conductor lucky draw (Save Week mode).</span>
+                        </div>
+                        <div class="form-group">
+                            <label for="vip-donation-threshold">VIP Seat Donation Threshold:</label>
+                            <input type="number" id="vip-donation-threshold" min="0" required>
+                            <span class="help-text">Minimum weekly tech donations to enter the VIP seat lucky draw (Save Week mode).</span>
+                        </div>
+                    </div>
+
+                    <div class="settings-group">
                         <h4>⚡ Power Tracking</h4>
                         <div class="form-group">
                             <label class="checkbox-label">

--- a/static/settings.js
+++ b/static/settings.js
@@ -42,6 +42,13 @@ async function loadSettings() {
         document.getElementById('vs-daily-target').value = settings.vs_points_daily_target || 0;
         document.getElementById('vs-weekly-target').value = settings.vs_points_weekly_target || 0;
 
+        // Donation targets
+        document.getElementById('donation-weekly-target').value = settings.donation_weekly_target || 0;
+        document.getElementById('conductor-donation-threshold').value =
+            settings.conductor_donation_threshold !== undefined ? settings.conductor_donation_threshold : 60000;
+        document.getElementById('vip-donation-threshold').value =
+            settings.vip_donation_threshold !== undefined ? settings.vip_donation_threshold : 40000;
+
         // Recruitment requirements
         document.getElementById('min-power').value = settings.min_power || 0;
         document.getElementById('min-hq-level').value = settings.min_hq_level || 0;
@@ -95,6 +102,9 @@ document.getElementById('settings-form').addEventListener('submit', async (e) =>
         daily_message_template: document.getElementById('daily-message-template').value,
         vs_points_daily_target: parseInt(document.getElementById('vs-daily-target').value) || 0,
         vs_points_weekly_target: parseInt(document.getElementById('vs-weekly-target').value) || 0,
+        donation_weekly_target: parseInt(document.getElementById('donation-weekly-target').value) || 0,
+        conductor_donation_threshold: parseInt(document.getElementById('conductor-donation-threshold').value) || 0,
+        vip_donation_threshold: parseInt(document.getElementById('vip-donation-threshold').value) || 0,
         min_power: parseInt(document.getElementById('min-power').value) || 0,
         min_hq_level: parseInt(document.getElementById('min-hq-level').value) || 0,
         power_tracking_enabled: document.getElementById('power-tracking-enabled').checked,


### PR DESCRIPTION
## Problem

Member import from General Power screenshots produced garbage names and dropped rows: single-pass tesseract output on the whole member region misread badges, split roster rows, and emitted fragments like `Tr.`, `mau`, `2f1 tonton nico`. Initial validation detected only 65/92 roster members.

## Fix

`ocrMembersWholeRegion` now fuses three readings per screenshot (grayscale block, high-contrast block, sparse text mode) instead of trusting one pass:

- Badge/name readings from a row's own power line and from power-less lines attached within one row are merged, so split readings (`R4 MKJUL` above `94929239`, or `Aa R2| 55443471` above `[R2| tonton nico`) still recover the name
- Power-less lines attach bidirectionally; on distance ties the power line that lost its own name wins
- Rank badges are majority-voted across readings
- Emitted names need >=3 letters, dropping junk fragments
- Parser minimum name length raised to 3; near-miss OCR names (similarity >= 0.8, containment, or small edit distance) are adopted onto existing members instead of creating duplicates

## Validation (all real screenshots)

| Flow | Result |
|---|---|
| Member import, 14 General Power screenshots | **92/92 roster members detected** (was 65/92), only 2 accepted extras from the pinned selected-member row |
| Power history, same 14 | 92 saved / 0 failed |
| VS Monday, 13 screenshots | 68 updated, 32 flagged for manual review |
| Desert Storm, 2 screenshots | all parsed, participants fuzzy-matched to members |
| Zombie Siege, 13 screenshots | parsed, 28/30 participants matched to members |

Known residuals (accepted):
- Mmorgane's rank badge reads R2 in some screenshots, R3 in others (badge is genuinely ambiguous in the source)
- Pinned bottom row occasionally garbles into preview extras (Seerkirure/roche) that the user can uncheck
- Marshal Guard name extraction on these screenshots is poor — separate extractor, pre-existing, tracked via #4 feedback