### PR TITLE
docs: cover GHCR image and pull-based updates

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -110,8 +110,8 @@ docker compose down
 # Restart
 docker compose restart
 
-# Rebuild after a code change
-docker compose up -d --build
+# Pull the latest published image and recreate the container
+docker compose pull && docker compose up -d
 
 # Open a shell inside the running container
 docker compose exec lastwar sh
@@ -140,11 +140,15 @@ echo "0 2 * * * root /usr/local/bin/backup-lastwar.sh" | sudo tee /etc/cron.d/la
 
 ### 8. Updating the Application (Docker)
 
+The production compose file pulls the published image from GHCR, so updates need no rebuild:
+
 ```bash
 cd /opt/lastwar
-git pull
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
+
+Optionally `git pull` first if you also want the latest compose file or docs.
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -200,7 +200,7 @@ docker compose up -d              # Start (detached)
 docker compose down               # Stop
 docker compose logs -f            # Tail logs
 docker compose restart            # Restart
-docker compose up -d --build      # Rebuild after code change
+docker compose pull && docker compose up -d   # Update to latest image
 ```
 
 ### Systemd Service (Bare-Metal)
@@ -265,10 +265,9 @@ curl https://www.ssllabs.com/ssltest/analyze.html?d=your-domain.com
 # Update system packages
 sudo apt update && sudo apt upgrade -y
 
-# Update application (Docker)
+# Update application (Docker) — pulls the latest published image
 cd /opt/lastwar
-git pull
-docker compose up -d --build
+docker compose pull && docker compose up -d
 
 # Update application (bare-metal)
 cd /opt/lastwar

--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for the comprehensive production guide coveri
 Production images are published to GitHub Container Registry — no clone or Go toolchain needed:
 
 ```bash
-# Generate a session key once:
-export SESSION_KEY=$(openssl rand -hex 32)
+# Grab the production compose file (or clone the repo):
+curl -O https://raw.githubusercontent.com/vervelak/lastwar-alliance-manager/main/docker-compose.yml
+
+# Set a session key via .env (Compose reads it automatically):
+echo "SESSION_KEY=$(openssl rand -hex 32)" > .env && chmod 600 .env
 
 docker compose up -d          # Docker
 # -- or --
@@ -111,6 +114,8 @@ podman-compose up -d          # Podman
 # The app is now running at http://localhost:8080
 # The SQLite database is persisted in ./data/alliance.db
 ```
+
+**Container image:** `ghcr.io/vervelak/lastwar-alliance-manager` — built for `linux/amd64` and `linux/arm64` (Raspberry Pi works), published automatically on every merge to `main` and on version tags. Tags: `latest`, semver (e.g. `1.2.3`), `main`, and commit sha.
 
 To test local code changes instead, build from source with the dev compose file:
 `docker compose -f docker-compose.dev.yml up -d --build`


### PR DESCRIPTION
Follow-up to #62. Aligns all docs with the published container image:

- README: production setup without cloning (curl the compose file), `.env` for `SESSION_KEY`, documents `ghcr.io/vervelak/lastwar-alliance-manager` — amd64/arm64, tags (`latest`, semver, `main`, sha), publish triggers
- DEPLOYMENT.md: updating = `docker compose pull && docker compose up -d` (no git pull/rebuild needed); useful-commands section matches
- QUICKSTART.md: same pull-based update commands

Docs-only change.