### PR TITLE
ci: chain release image publish from release-please

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to publish (e.g. v1.2.3)
+        type: string
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -43,13 +49,24 @@ jobs:
             type=ref,event=branch
             type=sha
 
+      - name: Compute release tags
+        if: inputs.tag != ''
+        id: reltags
+        run: |
+          V="${{ inputs.tag }}"
+          V="${V#v}"
+          MAJOR="${V%%.*}"
+          MINOR="${V#*.}"; MINOR="${MINOR%%.*}"
+          IMG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          echo "tags=$IMG:$V,$IMG:$MAJOR.$MINOR,$IMG:latest" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ inputs.tag != '' && steps.reltags.outputs.tags || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,13 +7,27 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - id: release
+        uses: google-github-actions/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Tags pushed by release-please use GITHUB_TOKEN, which does not trigger
+  # other workflow runs, so publish the release image from here instead.
+  publish-release-image:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
GITHUB_TOKEN tag pushes do not trigger workflows, so release-please tags never published semver image tags. Make docker-publish.yml reusable (workflow_call with tag input) and call it from release-please.yml when a release is created. Publishes vX.Y.Z, X.Y and latest.