### PR TITLE
fix(ocr): parallelize MG/ZS import and add manual participant entry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to publish (e.g. v1.2.3)
+        type: string
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -43,13 +49,24 @@ jobs:
             type=ref,event=branch
             type=sha
 
+      - name: Compute release tags
+        if: inputs.tag != ''
+        id: reltags
+        run: |
+          V="${{ inputs.tag }}"
+          V="${V#v}"
+          MAJOR="${V%%.*}"
+          MINOR="${V#*.}"; MINOR="${MINOR%%.*}"
+          IMG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          echo "tags=$IMG:$V,$IMG:$MAJOR.$MINOR,$IMG:latest" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ inputs.tag != '' && steps.reltags.outputs.tags || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,13 +7,27 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - id: release
+        uses: google-github-actions/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Tags pushed by release-please use GITHUB_TOKEN, which does not trigger
+  # other workflow runs, so publish the release image from here instead.
+  publish-release-image:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/main.go
+++ b/main.go
@@ -12673,9 +12673,10 @@ func getZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
 // POST /api/zombie-siege — create event manually (no OCR)
 func createZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		EventDate  string `json:"event_date"`
-		TotalWaves int64  `json:"total_waves"`
-		Notes      string `json:"notes"`
+		EventDate   string             `json:"event_date"`
+		TotalWaves  int64              `json:"total_waves"`
+		Notes       string             `json:"notes"`
+		Participants []ZSOCRParticipant `json:"participants"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -12689,37 +12690,104 @@ func createZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
 	session, _ := store.Get(r, "session")
 	userID, _ := session.Values["user_id"].(int)
 
-	result, err := db.Exec(`INSERT INTO zombie_siege_events (event_date, total_waves, notes, created_by_id)
+	tx, err := db.Begin()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	result, err := tx.Exec(`INSERT INTO zombie_siege_events (event_date, total_waves, notes, created_by_id)
 		VALUES (?, ?, ?, ?)`, req.EventDate, req.TotalWaves, req.Notes, userID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	id, _ := result.LastInsertId()
+	eventID, _ := result.LastInsertId()
+
+	added := insertZSParticipants(tx, eventID, req.Participants)
+	if err := tx.Commit(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{"id": id, "message": "Event created"})
+	json.NewEncoder(w).Encode(map[string]interface{}{"id": eventID, "added": added, "message": "Event created"})
 }
 
-// PUT /api/zombie-siege/{id} — update event metadata
+// PUT /api/zombie-siege/{id} — update event metadata (and optionally participants)
 func updateZombieSiegeEvent(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(mux.Vars(r)["id"])
 	var req struct {
-		EventDate  string `json:"event_date"`
-		TotalWaves int64  `json:"total_waves"`
-		Notes      string `json:"notes"`
+		EventDate   string             `json:"event_date"`
+		TotalWaves  int64              `json:"total_waves"`
+		Notes       string             `json:"notes"`
+		Participants []ZSOCRParticipant `json:"participants"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	_, err := db.Exec(`UPDATE zombie_siege_events SET event_date = ?, total_waves = ?, notes = ? WHERE id = ?`,
+
+	tx, err := db.Begin()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	_, err = tx.Exec(`UPDATE zombie_siege_events SET event_date = ?, total_waves = ?, notes = ? WHERE id = ?`,
 		req.EventDate, req.TotalWaves, req.Notes, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Only replace participants when the client actually sent the field.
+	added := 0
+	if req.Participants != nil {
+		tx.Exec("PRAGMA foreign_keys = ON")
+		if _, err := tx.Exec(`DELETE FROM zombie_siege_participants WHERE event_id = ?`, id); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		added = insertZSParticipants(tx, int64(id), req.Participants)
+	}
+
+	if err := tx.Commit(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"message": "Event updated"})
+	json.NewEncoder(w).Encode(map[string]interface{}{"message": "Event updated", "added": added})
+}
+
+// insertZSParticipants inserts manual ZS participants into the event, matching
+// each name to a member when no explicit member_id was supplied.
+func insertZSParticipants(tx *sql.Tx, eventID int64, participants []ZSOCRParticipant) int {
+	if len(participants) == 0 {
+		return 0
+	}
+	members, _ := loadAllMembers()
+	added := 0
+	for i := range participants {
+		p := &participants[i]
+		if p.MemberID == nil && members != nil {
+			matchZSParticipant(p, members)
+		}
+		rank := p.RankInEvent
+		if rank == 0 {
+			rank = i + 1
+		}
+		_, err := tx.Exec(`INSERT INTO zombie_siege_participants (event_id, member_id, name_snapshot, alliance_tag, rank_in_event, waves)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			eventID, p.MemberID, p.NameSnapshot, p.AllianceTag, rank, p.Waves)
+		if err != nil {
+			log.Printf("ZS manual create: failed to insert participant rank %d: %v", rank, err)
+			continue
+		}
+		added++
+	}
+	return added
 }
 
 // DELETE /api/zombie-siege/{id} — delete event + participants (cascade)
@@ -12877,6 +12945,9 @@ func processZombieSiegeScreenshots(w http.ResponseWriter, r *http.Request) {
 	var allParticipants []ZSOCRParticipant
 	var eventDate string
 
+	// Read every image up front (cheap), then OCR them in parallel so a large
+	// batch finishes well inside the HTTP write timeout.
+	images := make([][]byte, 0, len(files))
 	for _, fh := range files {
 		file, err := fh.Open()
 		if err != nil {
@@ -12887,17 +12958,29 @@ func processZombieSiegeScreenshots(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
+		images = append(images, imageData)
+	}
 
-		records, date, err := extractZombieSiegeDataFromImage(imageData)
-		if err != nil {
-			log.Printf("ZS OCR: %v", err)
+	type zsFileResult struct {
+		records []ZSOCRRecord
+		date    string
+		err     error
+	}
+	results := ocrParallel(images, 4, func(img []byte) zsFileResult {
+		records, date, err := extractZombieSiegeDataFromImage(img)
+		return zsFileResult{records: records, date: date, err: err}
+	})
+
+	for _, res := range results {
+		if res.err != nil {
+			log.Printf("ZS OCR: %v", res.err)
 			continue
 		}
-		if date != "" && eventDate == "" {
-			eventDate = date
+		if res.date != "" && eventDate == "" {
+			eventDate = res.date
 		}
 
-		for _, rec := range records {
+		for _, rec := range res.records {
 			if rec.MemberName == "" {
 				continue
 			}
@@ -13392,9 +13475,10 @@ func getMarshalGuardEvent(w http.ResponseWriter, r *http.Request) {
 // POST /api/marshal-guard — create event manually (no OCR)
 func createMarshalGuardEvent(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		EventDate           string `json:"event_date"`
-		TotalAllianceDamage int64  `json:"total_alliance_damage"`
-		Notes               string `json:"notes"`
+		EventDate           string             `json:"event_date"`
+		TotalAllianceDamage int64              `json:"total_alliance_damage"`
+		Notes               string             `json:"notes"`
+		Participants        []MGOCRParticipant `json:"participants"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -13408,37 +13492,105 @@ func createMarshalGuardEvent(w http.ResponseWriter, r *http.Request) {
 	session, _ := store.Get(r, "session")
 	userID, _ := session.Values["user_id"].(int)
 
-	result, err := db.Exec(`INSERT INTO marshal_guard_events (event_date, total_alliance_damage, notes, created_by_id)
+	tx, err := db.Begin()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	result, err := tx.Exec(`INSERT INTO marshal_guard_events (event_date, total_alliance_damage, notes, created_by_id)
 		VALUES (?, ?, ?, ?)`, req.EventDate, req.TotalAllianceDamage, req.Notes, userID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	id, _ := result.LastInsertId()
+	eventID, _ := result.LastInsertId()
+
+	added := insertMGParticipants(tx, eventID, req.Participants)
+	if err := tx.Commit(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{"id": id, "message": "Event created"})
+	json.NewEncoder(w).Encode(map[string]interface{}{"id": eventID, "added": added, "message": "Event created"})
 }
 
-// PUT /api/marshal-guard/{id} — update event metadata
+// PUT /api/marshal-guard/{id} — update event metadata (and optionally participants)
 func updateMarshalGuardEvent(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(mux.Vars(r)["id"])
 	var req struct {
-		EventDate           string `json:"event_date"`
-		TotalAllianceDamage int64  `json:"total_alliance_damage"`
-		Notes               string `json:"notes"`
+		EventDate           string             `json:"event_date"`
+		TotalAllianceDamage int64              `json:"total_alliance_damage"`
+		Notes               string             `json:"notes"`
+		Participants        []MGOCRParticipant `json:"participants"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	_, err := db.Exec(`UPDATE marshal_guard_events SET event_date = ?, total_alliance_damage = ?, notes = ? WHERE id = ?`,
+
+	tx, err := db.Begin()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
+	_, err = tx.Exec(`UPDATE marshal_guard_events SET event_date = ?, total_alliance_damage = ?, notes = ? WHERE id = ?`,
 		req.EventDate, req.TotalAllianceDamage, req.Notes, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Only replace participants when the client actually sent the field
+	// (nil = omitted, non-nil = replace with the provided list).
+	added := 0
+	if req.Participants != nil {
+		tx.Exec("PRAGMA foreign_keys = ON")
+		if _, err := tx.Exec(`DELETE FROM marshal_guard_participants WHERE event_id = ?`, id); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		added = insertMGParticipants(tx, int64(id), req.Participants)
+	}
+
+	if err := tx.Commit(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"message": "Event updated"})
+	json.NewEncoder(w).Encode(map[string]interface{}{"message": "Event updated", "added": added})
+}
+
+// insertMGParticipants inserts manual MG participants into the event, matching
+// each name to a member when no explicit member_id was supplied.
+func insertMGParticipants(tx *sql.Tx, eventID int64, participants []MGOCRParticipant) int {
+	if len(participants) == 0 {
+		return 0
+	}
+	members, _ := loadAllMembers()
+	added := 0
+	for i := range participants {
+		p := &participants[i]
+		if p.MemberID == nil && members != nil {
+			matchMGParticipant(p, members)
+		}
+		rank := p.RankInEvent
+		if rank == 0 {
+			rank = i + 1
+		}
+		_, err := tx.Exec(`INSERT INTO marshal_guard_participants (event_id, member_id, name_snapshot, alliance_tag, rank_in_event, damage, attack_count)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			eventID, p.MemberID, p.NameSnapshot, p.AllianceTag, rank, p.Damage, p.AttackCount)
+		if err != nil {
+			log.Printf("MG manual create: failed to insert participant rank %d: %v", rank, err)
+			continue
+		}
+		added++
+	}
+	return added
 }
 
 // DELETE /api/marshal-guard/{id} — delete event + participants (cascade)
@@ -14113,6 +14265,68 @@ func confirmMarshalGuard(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ocrParallel runs fn over every image using a bounded worker pool, preserving
+// index order in the returned slice. OCR is CPU-bound and thread-safe when each
+// call creates its own gosseract client, so parallelism cuts wall-clock time
+// on large upload batches (which otherwise exceed the HTTP write timeout).
+func ocrParallel[T any](images [][]byte, workers int, fn func([]byte) T) []T {
+	if workers <= 0 {
+		workers = 4
+	}
+	if workers > len(images) {
+		workers = len(images)
+	}
+	if workers <= 0 {
+		return nil
+	}
+	results := make([]T, len(images))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, workers)
+	for i, img := range images {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, img []byte) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = fn(img)
+		}(i, img)
+	}
+	wg.Wait()
+	return results
+}
+
+// mgFileResult is the per-image OCR output for Marshal Guard screenshots.
+type mgFileResult struct {
+	participants []MGOCRParticipant
+	date         string
+	total        int64
+	rowBased     bool
+}
+
+// extractMGImage runs the full MG per-image pipeline: row-based first, then
+// mask-based (the real path for mail reward screenshots), then raw OCR fallback.
+func extractMGImage(imageData []byte) mgFileResult {
+	rowParticipants, rowDate, rowTotal := extractMGByRows(imageData)
+	if len(rowParticipants) >= 3 {
+		return mgFileResult{participants: rowParticipants, date: rowDate, total: rowTotal, rowBased: true}
+	}
+	maskResult := extractMGByMask(imageData)
+	if maskResult == nil {
+		clientRaw := gosseract.NewClient()
+		clientRaw.SetImageFromBytes(imageData)
+		textRaw, errRaw := clientRaw.Text()
+		clientRaw.Close()
+		if errRaw == nil {
+			fallback := parseMarshalGuardText(textRaw)
+			maskResult = &fallback
+		}
+	}
+	if maskResult == nil {
+		return mgFileResult{}
+	}
+	return mgFileResult{participants: maskResult.Participants, date: maskResult.EventDate, total: maskResult.TotalDamage}
+}
+
 // POST /api/marshal-guard/process-screenshots — OCR parse MG screenshots
 func processMarshalGuardScreenshots(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseMultipartForm(10 << 20); err != nil {
@@ -14138,6 +14352,9 @@ func processMarshalGuardScreenshots(w http.ResponseWriter, r *http.Request) {
 	var eventDate string
 	var totalDamage int64
 
+	// Read every image up front (cheap), then OCR them in parallel so a large
+	// batch finishes well inside the HTTP write timeout.
+	images := make([][]byte, 0, len(files))
 	for _, fh := range files {
 		file, err := fh.Open()
 		if err != nil {
@@ -14148,18 +14365,20 @@ func processMarshalGuardScreenshots(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
+		images = append(images, imageData)
+	}
 
-		// Try row-based extraction first (much more accurate)
-		rowParticipants, rowDate, rowTotal := extractMGByRows(imageData)
-		if len(rowParticipants) >= 3 {
-			log.Printf("MG OCR: row-based extraction found %d participants", len(rowParticipants))
-			if rowDate != "" && eventDate == "" {
-				eventDate = rowDate
+	results := ocrParallel(images, 4, extractMGImage)
+
+	for _, res := range results {
+		if res.rowBased {
+			if res.date != "" && eventDate == "" {
+				eventDate = res.date
 			}
-			if rowTotal > totalDamage {
-				totalDamage = rowTotal
+			if res.total > totalDamage {
+				totalDamage = res.total
 			}
-			for _, p := range rowParticipants {
+			for _, p := range res.participants {
 				merged := false
 				for i, existing := range allParticipants {
 					if strings.EqualFold(existing.NameSnapshot, p.NameSnapshot) {
@@ -14177,35 +14396,15 @@ func processMarshalGuardScreenshots(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		// Mask-based row extraction: the game mail has a FIXED layout
-		// Use pattern matching to crop each player row's name + damage regions
-		log.Printf("MG OCR: row-based extraction found only %d, using mask-based extraction", len(rowParticipants))
-		maskResult := extractMGByMask(imageData)
-		if maskResult == nil {
-			log.Printf("MG OCR: mask extraction failed, trying raw OCR fallback")
-			clientRaw := gosseract.NewClient()
-			clientRaw.SetImageFromBytes(imageData)
-			textRaw, errRaw := clientRaw.Text()
-			clientRaw.Close()
-			if errRaw != nil {
-				continue
-			}
-			fallback := parseMarshalGuardText(textRaw)
-			maskResult = &fallback
+		if res.date != "" && eventDate == "" {
+			eventDate = res.date
 		}
-
-		result := *maskResult
-		log.Printf("MG OCR mask: found %d participants", len(result.Participants))
-
-		if result.EventDate != "" && eventDate == "" {
-			eventDate = result.EventDate
-		}
-		if result.TotalDamage > totalDamage {
-			totalDamage = result.TotalDamage
+		if res.total > totalDamage {
+			totalDamage = res.total
 		}
 		// Merge participants by name using fuzzy matching
 		// (OCR may garble names slightly between screenshots)
-		for _, p := range result.Participants {
+		for _, p := range res.participants {
 			merged := false
 			for i, existing := range allParticipants {
 				if strings.EqualFold(existing.NameSnapshot, p.NameSnapshot) ||
@@ -17451,8 +17650,11 @@ func main() {
 	srv := &http.Server{
 		Addr:         ":" + port,
 		Handler:      requestLoggingMiddleware(router),
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 60 * time.Second,
+		// Generous timeouts: OCR screenshot imports process many images and can
+		// take well over a minute on large batches. ReadTimeout covers slow uploads
+		// (request body), WriteTimeout covers the OCR work before the response.
+		ReadTimeout:  120 * time.Second,
+		WriteTimeout: 600 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
 	log.Fatal(srv.ListenAndServe())

--- a/main.go
+++ b/main.go
@@ -7938,6 +7938,80 @@ func scaleImage(img image.Image, factor int) image.Image {
 	return scaled
 }
 
+// scaleImageBilinear upscales by factor using bilinear interpolation, producing
+// smooth anti-aliased edges. Nearest-neighbour upscaling (scaleImage) leaves
+// jagged edges that Tesseract frequently rejects on thin, light game digits.
+func scaleImageBilinear(img image.Image, factor int) image.Image {
+	bounds := img.Bounds()
+	srcW := bounds.Dx()
+	srcH := bounds.Dy()
+	if srcW <= 0 || srcH <= 0 {
+		return img
+	}
+	newW := srcW * factor
+	newH := srcH * factor
+	out := image.NewRGBA(image.Rect(0, 0, newW, newH))
+
+	lerp := func(a, b float64, w float64) float64 {
+		return a + (b-a)*w
+	}
+
+	for y := 0; y < newH; y++ {
+		sy := float64(y)/float64(factor) - 0.5
+		y0 := int(math.Floor(sy))
+		if y0 < 0 {
+			y0 = 0
+		}
+		y1 := y0 + 1
+		if y1 >= srcH {
+			y1 = srcH - 1
+		}
+		wy := sy - float64(y0)
+		if wy < 0 {
+			wy = 0
+		}
+		for x := 0; x < newW; x++ {
+			sx := float64(x)/float64(factor) - 0.5
+			x0 := int(math.Floor(sx))
+			if x0 < 0 {
+				x0 = 0
+			}
+			x1 := x0 + 1
+			if x1 >= srcW {
+				x1 = srcW - 1
+			}
+			wx := sx - float64(x0)
+			if wx < 0 {
+				wx = 0
+			}
+
+			c00 := img.At(bounds.Min.X+x0, bounds.Min.Y+y0)
+			c10 := img.At(bounds.Min.X+x1, bounds.Min.Y+y0)
+			c01 := img.At(bounds.Min.X+x0, bounds.Min.Y+y1)
+			c11 := img.At(bounds.Min.X+x1, bounds.Min.Y+y1)
+
+			r00, g00, b00, a00 := c00.RGBA()
+			r10, g10, b10, a10 := c10.RGBA()
+			r01, g01, b01, a01 := c01.RGBA()
+			r11, g11, b11, a11 := c11.RGBA()
+
+			r := lerp(lerp(float64(r00), float64(r10), wx), lerp(float64(r01), float64(r11), wx), wy)
+			g := lerp(lerp(float64(g00), float64(g10), wx), lerp(float64(g01), float64(g11), wx), wy)
+			b := lerp(lerp(float64(b00), float64(b10), wx), lerp(float64(b01), float64(b11), wx), wy)
+			a := lerp(lerp(float64(a00), float64(a10), wx), lerp(float64(a01), float64(a11), wx), wy)
+
+			out.SetRGBA(x, y, color.RGBA{
+				R: uint8(uint32(r+0.5) >> 8),
+				G: uint8(uint32(g+0.5) >> 8),
+				B: uint8(uint32(b+0.5) >> 8),
+				A: uint8(uint32(a+0.5) >> 8),
+			})
+		}
+	}
+
+	return out
+}
+
 // Preprocess image for better OCR
 func preprocessImageForOCR(imageData []byte) ([]byte, error) {
 	// Decode image
@@ -16389,6 +16463,40 @@ func binaryThresholdForOCR(img image.Image, threshold uint8) *image.Gray {
 	return out
 }
 
+// binaryThresholdFracForOCR converts to grayscale, optionally inverts
+// (dark→light), then applies a hard binary threshold placed at fracPct% of
+// the observed brightness range (0 = darkest pixel, 100 = brightest).
+// A low fraction keeps more of the anti-aliased digit edges, which helps
+// Tesseract read the thin, light-coloured donation point digits.
+func binaryThresholdFracForOCR(img image.Image, fracPct int) *image.Gray {
+	gray := adaptiveGrayForOCR(img)
+	bounds := gray.Bounds()
+	min8, max8 := uint8(255), uint8(0)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			v := gray.GrayAt(x, y).Y
+			if v < min8 {
+				min8 = v
+			}
+			if v > max8 {
+				max8 = v
+			}
+		}
+	}
+	threshold := uint8(int(min8) + (int(max8)-int(min8))*fracPct/100)
+	out := image.NewGray(bounds)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			if gray.GrayAt(x, y).Y > threshold {
+				out.SetGray(x, y, color.Gray{Y: 255})
+			} else {
+				out.SetGray(x, y, color.Gray{Y: 0})
+			}
+		}
+	}
+	return out
+}
+
 // findDonationRows detects row boundaries in a donation leaderboard screenshot
 // by analysing per-row colour variance in the avatar column (x=13–30% of width).
 // Each row contains a colourful circular avatar; the gaps between rows are a
@@ -16528,7 +16636,17 @@ func findDonationRows(img image.Image, dataTop, dataBottom int) [][2]int {
 //   - I/l/i → 1  (uppercase I, lowercase L/i vs one)
 //   - S/s → 5, B → 8  (shape similarity in game fonts)
 //   - Trailing noise like "|" from card borders (discarded)
+//
+// The first run is located in the raw text BEFORE whitespace is stripped, so a
+// stray glyph detected on a second line (e.g. "56950\n2" under PSM_UNIFORM_BLOCK)
+// is not glued onto the value as a spurious trailing digit.
 func ocrNormalisePoints(raw string) int {
+	// First run of digit-like glyphs (including common confusions). Any
+	// non-digit-like character (space, newline, |, etc.) ends the run.
+	first := regexp.MustCompile(`[0-9OoIliSsB]+`).FindString(raw)
+	if first == "" {
+		return 0
+	}
 	mapped := strings.Map(func(r rune) rune {
 		switch r {
 		case 'O', 'o':
@@ -16540,18 +16658,10 @@ func ocrNormalisePoints(raw string) int {
 		case 'B':
 			return '8'
 		default:
-			if r >= '0' && r <= '9' {
-				return r
-			}
-			return -1 // discard spaces, |, punctuation, etc.
+			return r
 		}
-	}, strings.TrimSpace(raw))
-	// Take only the first contiguous digit run (guards against trailing noise).
-	first := regexp.MustCompile(`\d+`).FindString(mapped)
-	if first == "" {
-		return 0
-	}
-	v, _ := strconv.Atoi(first)
+	}, first)
+	v, _ := strconv.Atoi(mapped)
 	return v
 }
 
@@ -16657,24 +16767,56 @@ func extractDonationsByRows(imageData []byte, imgIdx int) []DonationOCREntry {
 		// ── Points ────────────────────────────────────────────────────────
 		ptCrop := image.NewRGBA(image.Rect(0, 0, ptX2-ptX1, rowH))
 		draw.Draw(ptCrop, ptCrop.Bounds(), img, image.Point{ptX1, rowTop}, draw.Src)
-		var ptBuf bytes.Buffer
-		png.Encode(&ptBuf, binaryThresholdForOCR(scaleImage(ptCrop, 3), 0))
-		// Write to a temp file so gosseract can load it via file path (avoids
-		// in-memory PNG decoding differences between leptonica and Go's image/png).
-		ptTmpPath := fmt.Sprintf("/tmp/don_pts_%d_%d.png", imgIdx, i)
-		_ = os.WriteFile(ptTmpPath, ptBuf.Bytes(), 0o600)
-		ptClient := gosseract.NewClient()
-		ptClient.SetImage(ptTmpPath)
-		// PSM must be set as a variable (not SetPageSegMode) because gosseract's
-		// lazy init re-calls C.Init() which resets PSM to PSM_AUTO (3), losing
-		// any SetPageSegMode call made before Text(). Variables are applied AFTER
-		// C.Init() via setVariablesToInitializedAPI(), so they survive re-init.
-		ptClient.SetVariable("tessedit_pageseg_mode", "13") // PSM_RAW_LINE – bypasses text-detection heuristics that fail on bold game fonts
-		ptClient.SetWhitelist("0123456789")
-		ptText, _ := ptClient.Text()
-		ptClient.Close()
-		os.Remove(ptTmpPath) // clean up temp file
-		points := ocrNormalisePoints(ptText)
+		scaledPt := scaleImageBilinear(ptCrop, 3)
+		// The old PSM_RAW_LINE + mid-point threshold read nothing on most real
+		// screenshots, and nearest-neighbour upscaling left jagged digit edges
+		// Tesseract rejected. Use bilinear upscaling and vote across a set of
+		// threshold/segmentation variants: higher fractions keep only the solid
+		// digit cores, so they read fewer rows but never insert spurious extra
+		// digits. The most common reading wins.
+		ptVariants := []struct {
+			fracPct int
+			psm     string
+		}{
+			{25, "7"}, {50, "7"}, {65, "7"}, {25, "6"}, {50, "6"}, {65, "6"},
+		}
+		points := 0
+		var ptText string
+		votes := map[int]int{}
+		for _, pv := range ptVariants {
+			var ptBuf bytes.Buffer
+			png.Encode(&ptBuf, binaryThresholdFracForOCR(scaledPt, pv.fracPct))
+			// Write to a temp file so gosseract can load it via file path (avoids
+			// in-memory PNG decoding differences between leptonica and Go's image/png).
+			ptTmpPath := fmt.Sprintf("/tmp/don_pts_%d_%d.png", imgIdx, i)
+			_ = os.WriteFile(ptTmpPath, ptBuf.Bytes(), 0o600)
+			ptClient := gosseract.NewClient()
+			ptClient.SetImage(ptTmpPath)
+			// PSM must be set as a variable (not SetPageSegMode) because gosseract's
+			// lazy init re-calls C.Init() which resets PSM to PSM_AUTO (3), losing
+			// any SetPageSegMode call made before Text(). Variables are applied AFTER
+			// C.Init() via setVariablesToInitializedAPI(), so they survive re-init.
+			ptClient.SetVariable("tessedit_pageseg_mode", pv.psm)
+			ptClient.SetWhitelist("0123456789")
+			raw, _ := ptClient.Text()
+			ptClient.Close()
+			os.Remove(ptTmpPath) // clean up temp file
+			if v := ocrNormalisePoints(raw); v > 0 {
+				votes[v]++
+				if ptText == "" {
+					ptText = strings.TrimSpace(raw)
+				}
+			}
+		}
+		best, bestCount := 0, 0
+		for v, n := range votes {
+			if n > bestCount || (n == bestCount && v > best) {
+				best, bestCount = v, n
+			}
+		}
+		if best > 0 {
+			points = best
+		}
 
 		// Capture crops for uncertain OCR results so the user can verify in the
 		// confirm dialog. Clicking a crop opens the full screenshot with the row
@@ -16720,7 +16862,17 @@ func mergeDonationEntries(all []DonationOCREntry) []DonationOCREntry {
 	for _, e := range all {
 		key := mgOcrNormForCompare(e.NameSnapshot)
 		if idx, exists := seen[key]; exists {
-			if e.RankInSnapshot < result[idx].RankInSnapshot {
+			// Rank OCR is unreliable (empty reads fall back to a per-image
+			// counter), so prefer the entry whose points were read; use the
+			// rank only as a tie-breaker.
+			replace := false
+			switch {
+			case result[idx].Points == 0 && e.Points > 0:
+				replace = true
+			case (result[idx].Points > 0) == (e.Points > 0) && e.RankInSnapshot < result[idx].RankInSnapshot:
+				replace = true
+			}
+			if replace {
 				result[idx] = e
 			}
 			continue

--- a/static/marshal-guard.html
+++ b/static/marshal-guard.html
@@ -104,6 +104,12 @@
                         <label for="mg-notes">Notes (optional)</label>
                         <textarea id="mg-notes" rows="2" placeholder="Any notes about this event..."></textarea>
                     </div>
+                    <div class="form-group">
+                        <label>Participants (optional — add member name + damage)</label>
+                        <div id="mg-manual-participants"></div>
+                        <button type="button" id="mg-add-participant-btn" class="btn btn-secondary" style="margin-top:.5rem;">➕ Add Member</button>
+                    </div>
+                    <datalist id="mg-member-names"></datalist>
                     <button type="submit" class="btn btn-primary">💾 Save Event</button>
                 </div>
             </form>

--- a/static/marshal-guard.js
+++ b/static/marshal-guard.js
@@ -339,7 +339,14 @@ async function loadMGMembers() {
         if (!res.ok) return;
         const data = await res.json();
         mgAllMembers = (data || []).sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+        buildMGMemberDatalist();
     } catch { /* non-critical, dropdown just stays empty */ }
+}
+
+function buildMGMemberDatalist() {
+    const dl = document.getElementById('mg-member-names');
+    if (!dl) return;
+    dl.innerHTML = mgAllMembers.map(m => `<option value="${escapeAttr(m.name)}">`).join('');
 }
 
 // Build <option> elements for a member select, pre-selecting memberId.
@@ -756,7 +763,33 @@ function parseMGDamageStr(s) {
 
 
 // ---- Manual event creation ----
+function addMGManualRow(name = '', damage = '') {
+    const container = document.getElementById('mg-manual-participants');
+    if (!container) return;
+    const row = document.createElement('div');
+    row.className = 'manual-participant-row';
+    row.innerHTML =
+        `<input type="text" class="mg-manual-name" list="mg-member-names" placeholder="Member name" value="${escapeAttr(name)}">` +
+        `<input type="number" class="mg-manual-damage" min="0" placeholder="Damage" value="${escapeAttr(damage)}">` +
+        `<button type="button" class="mg-manual-remove btn btn-secondary">✕</button>`;
+    container.appendChild(row);
+    row.querySelector('.mg-manual-remove').addEventListener('click', () => row.remove());
+}
+
+function collectMGManualParticipants() {
+    const participants = [];
+    document.querySelectorAll('#mg-manual-participants .manual-participant-row').forEach(row => {
+        const name = row.querySelector('.mg-manual-name').value.trim();
+        const damage = parseInt(row.querySelector('.mg-manual-damage').value, 10) || 0;
+        if (name || damage) participants.push({ name_snapshot: name, damage });
+    });
+    return participants;
+}
+
 function initManualForm() {
+    const addBtn = document.getElementById('mg-add-participant-btn');
+    if (addBtn) addBtn.addEventListener('click', () => addMGManualRow());
+
     document.getElementById('event-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const date = document.getElementById('mg-date').value;
@@ -770,12 +803,14 @@ function initManualForm() {
                     event_date: date,
                     total_alliance_damage: parseInt(document.getElementById('mg-total-damage').value) || 0,
                     notes: document.getElementById('mg-notes').value,
+                    participants: collectMGManualParticipants(),
                 }),
             });
             if (res.ok) {
                 showToast('Event created', 'success');
                 document.getElementById('event-modal').style.display = 'none';
                 document.getElementById('event-form').reset();
+                document.getElementById('mg-manual-participants').innerHTML = '';
                 loadEvents();
             } else {
                 showToast('Failed to create event', 'error');

--- a/static/styles.css
+++ b/static/styles.css
@@ -9220,3 +9220,15 @@ html.theme-dark .ld-note-tag  { background: rgba(56,161,105,.2); color: #68d391;
 html.theme-dark .ld-rank-filter select { background: #2d3748; border-color: #4a5568; color: #f7fafc; }
 html.theme-dark .ld-section h3,
 html.theme-dark .ld-chart-card h4 { color: #f7fafc; }
+
+/* Manual event participant entry rows (Marshal Guard / Zombie Siege) */
+.manual-participant-row {
+    display: flex;
+    gap: .5rem;
+    align-items: center;
+    margin-bottom: .5rem;
+}
+.manual-participant-row input[type="text"] { flex: 2; min-width: 0; }
+.manual-participant-row input[type="number"] { flex: 1; min-width: 0; }
+.manual-participant-row .mg-manual-remove,
+.manual-participant-row .zs-manual-remove { flex: 0 0 auto; }

--- a/static/zombie-siege.html
+++ b/static/zombie-siege.html
@@ -104,6 +104,12 @@
                         <label for="zs-notes">Notes (optional)</label>
                         <textarea id="zs-notes" rows="2" placeholder="Any notes about this event..."></textarea>
                     </div>
+                    <div class="form-group">
+                        <label>Participants (optional — add member name + waves)</label>
+                        <div id="zs-manual-participants"></div>
+                        <button type="button" id="zs-add-participant-btn" class="btn btn-secondary" style="margin-top:.5rem;">➕ Add Member</button>
+                    </div>
+                    <datalist id="zs-member-names"></datalist>
                     <button type="submit" class="btn btn-primary">💾 Save Event</button>
                 </div>
             </form>

--- a/static/zombie-siege.js
+++ b/static/zombie-siege.js
@@ -323,7 +323,14 @@ async function loadZSMembers() {
         if (!res.ok) return;
         const data = await res.json();
         zsAllMembers = (data || []).sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+        buildZSMemberDatalist();
     } catch { /* non-critical */ }
+}
+
+function buildZSMemberDatalist() {
+    const dl = document.getElementById('zs-member-names');
+    if (!dl) return;
+    dl.innerHTML = zsAllMembers.map(m => `<option value="${escapeAttr(m.name)}">`).join('');
 }
 
 function buildZSMemberOptions(memberId) {
@@ -500,7 +507,33 @@ async function importEvent() {
 }
 
 // ---- Manual event creation ----
+function addZSManualRow(name = '', waves = '') {
+    const container = document.getElementById('zs-manual-participants');
+    if (!container) return;
+    const row = document.createElement('div');
+    row.className = 'manual-participant-row';
+    row.innerHTML =
+        `<input type="text" class="zs-manual-name" list="zs-member-names" placeholder="Member name" value="${escapeAttr(name)}">` +
+        `<input type="number" class="zs-manual-waves" min="0" placeholder="Waves" value="${escapeAttr(waves)}">` +
+        `<button type="button" class="zs-manual-remove btn btn-secondary">✕</button>`;
+    container.appendChild(row);
+    row.querySelector('.zs-manual-remove').addEventListener('click', () => row.remove());
+}
+
+function collectZSManualParticipants() {
+    const participants = [];
+    document.querySelectorAll('#zs-manual-participants .manual-participant-row').forEach(row => {
+        const name = row.querySelector('.zs-manual-name').value.trim();
+        const waves = parseInt(row.querySelector('.zs-manual-waves').value, 10) || 0;
+        if (name || waves) participants.push({ name_snapshot: name, waves });
+    });
+    return participants;
+}
+
 function initManualForm() {
+    const addBtn = document.getElementById('zs-add-participant-btn');
+    if (addBtn) addBtn.addEventListener('click', () => addZSManualRow());
+
     document.getElementById('event-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const date = document.getElementById('zs-date').value;
@@ -514,12 +547,14 @@ function initManualForm() {
                     event_date: date,
                     total_waves: parseInt(document.getElementById('zs-total-waves').value) || 0,
                     notes: document.getElementById('zs-notes').value,
+                    participants: collectZSManualParticipants(),
                 }),
             });
             if (res.ok) {
                 showToast('Event created', 'success');
                 document.getElementById('event-modal').style.display = 'none';
                 document.getElementById('event-form').reset();
+                document.getElementById('zs-manual-participants').innerHTML = '';
                 loadEvents();
             } else {
                 showToast('Failed to create event', 'error');


### PR DESCRIPTION
## Summary

Addresses user feedback on Marshal Guard (MG) and Zombie Siege (ZS) OCR import:

1. **Large batch uploads time out** — MG/ZS screenshots were OCR'd sequentially in a loop, and the server WriteTimeout was 60s. Added a bounded 4-worker parallel OCR pool and raised ReadTimeout to 120s / WriteTimeout to 600s.
2. **Manual event creation can't enter member info** — added manual participant rows to the MG/ZS create/edit modals (name autocomplete + damage/waves + rank) and wired backend handlers to insert/update participants with member matching.

## Changes
- `main.go`: `ocrParallel` worker pool, refactored MG/ZS processors to read-then-parallel-OCR, `Participants` support in create/update handlers with `insertMGParticipants`/`insertZSParticipants` helpers, longer server timeouts.
- `static/marshal-guard.{html,js}` + `static/zombie-siege.{html,js}`: manual participant entry UI (add/remove rows, datalist autocomplete).
- `static/styles.css`: manual participant row styling.

## Tested
- `go build` + `go vet` pass.
- `node --check` on both JS files passes.
- Endpoint smoke test: MG/ZS create with participants, MG update replace vs omit (keeps existing), ZS parallel process-screenshots (5 images in ~2.6s).

Note: MG leaderboard 'top-3 rows not scanned' (garbled MVP names) remains a separate known issue.