### PR TITLE
fix(ocr): extract MG MVP card name and damage via band detection

### DIFF
--- a/mg_ocr.go
+++ b/mg_ocr.go
@@ -766,6 +766,135 @@ func mgFindColoredRegions(img image.Image, width, height int) []mgRect {
 
 // ─── Main processing function ─────────────────────────────────────────────────
 
+// mgMemberRowRects holds the crop rectangles for one detected member row.
+type mgMemberRowRects struct {
+	rankRect mgRect
+	nameRect mgRect
+	dmgRect  mgRect
+	rowY0    int // cropped y of the name-line top
+	rowY1    int // cropped y of the damage-line bottom
+}
+
+// mgLuma returns the 0-255 luminance of a pixel.
+func mgLuma(img image.Image, x, y int) int {
+	r, g, b, _ := img.At(x, y).RGBA()
+	return (299*int(r>>8) + 587*int(g>>8) + 114*int(b>>8)) / 1000
+}
+
+// mgEdgeLineRuns finds horizontal text lines inside a strip by counting, per
+// row, pixels where the luminance changes sharply over a 3-pixel horizontal
+// window (a text-stroke signature; smooth card backgrounds have none). Counts
+// are box-smoothed and thresholded; contiguous runs at least 6px tall are
+// returned as [y0, y1) intervals. The strip is given as fractions of the image.
+func mgEdgeLineRuns(img image.Image, cropW, cropH int, fx0, fx1, fy0, fy1 float64, threshold int) [][2]int {
+	x0 := int(fx0 * float64(cropW))
+	x1 := int(fx1 * float64(cropW))
+	y0 := int(fy0 * float64(cropH))
+	y1 := int(fy1 * float64(cropH))
+	if x1-x0 < 8 || y1-y0 < 8 {
+		return nil
+	}
+	counts := make([]int, y1-y0)
+	for yi := 0; yi < y1-y0; yi++ {
+		y := y0 + yi
+		c := 0
+		for x := x0; x < x1-3; x++ {
+			d := mgLuma(img, x+3, y) - mgLuma(img, x, y)
+			if d < 0 {
+				d = -d
+			}
+			if d > 40 {
+				c++
+			}
+		}
+		counts[yi] = c
+	}
+	sm := make([]int, y1-y0)
+	for i := range sm {
+		s, n := 0, 0
+		for k := -1; k <= 1; k++ {
+			j := i + k
+			if j >= 0 && j < len(sm) {
+				s += counts[j]
+				n++
+			}
+		}
+		sm[i] = s / n
+	}
+	const minH = 6
+	var runs [][2]int
+	inRun := false
+	runStart := 0
+	for i := 0; i < len(sm); i++ {
+		if sm[i] >= threshold {
+			if !inRun {
+				inRun = true
+				runStart = i
+			}
+		} else if inRun {
+			if i-runStart >= minH {
+				runs = append(runs, [2]int{y0 + runStart, y0 + i})
+			}
+			inRun = false
+		}
+	}
+	if inRun && len(sm)-runStart >= minH {
+		runs = append(runs, [2]int{y0 + runStart, y1})
+	}
+	return runs
+}
+
+// mgFindMemberRows locates the ranked member rows (ranks 2-6 in one shot) in a
+// Marshal Guard dialog crop using horizontal-edge line detection. It replaces
+// the brittle coloured-region vertical segmentation, which over-split names
+// containing spaces (e.g. "Theodore Silas") and dropped member rows.
+//
+// The rank badges and avatars (x < 0.34W) carry edge content across the gap
+// between a card's name and damage lines, so lines are detected on the
+// right-hand strip only (x in [0.34W, 0.72W]). There the name/damage gap is
+// near-zero while the gap between cards is a clear zero valley, cleanly
+// separating every name and damage line. Name/damage crops are then widened to
+// [0.35W, 0.85W] to capture long names and full damage values.
+func mgFindMemberRows(cropped image.Image, cropW, cropH int) []mgMemberRowRects {
+	// Locate the "Damage Ranking" header to anchor the table start.
+	bodyTop := int(0.40 * float64(cropH))
+	for _, ln := range mgEdgeLineRuns(cropped, cropW, cropH, 0.05, 0.95, 0.30, 0.45, 20) {
+		rect := mgRect{x0: int(0.05 * float64(cropW)), y0: ln[0] - 3, x1: int(0.95 * float64(cropW)), y1: ln[1] + 3}
+		if rect.y0 < 0 {
+			rect.y0 = 0
+		}
+		data, err := mgCropAndBinarize(cropped, rect, 0)
+		if err != nil {
+			continue
+		}
+		raw, _ := mgRunOCR(data, gosseract.PSM_SINGLE_LINE, "")
+		if strings.Contains(strings.ToLower(raw), "rank") {
+			bodyTop = ln[1] + 4
+			break
+		}
+	}
+
+	lines := mgEdgeLineRuns(cropped, cropW, cropH, 0.34, 0.72, float64(bodyTop)/float64(cropH), 0.90, 20)
+	var rects []mgMemberRowRects
+	for i := 0; i+1 < len(lines); {
+		nameLn, dmgLn := lines[i], lines[i+1]
+		gap := dmgLn[0] - nameLn[1]
+		if gap >= 0 && gap < 60 {
+			rects = append(rects, mgMemberRowRects{
+				rankRect: mgRect{x0: int(0.08 * float64(cropW)), y0: nameLn[0] - 3, x1: int(0.22 * float64(cropW)), y1: dmgLn[1] + 3},
+				nameRect: mgRect{x0: int(0.35 * float64(cropW)), y0: nameLn[0] - 3, x1: int(0.85 * float64(cropW)), y1: nameLn[1] + 3},
+				dmgRect:  mgRect{x0: int(0.35 * float64(cropW)), y0: dmgLn[0] - 3, x1: int(0.85 * float64(cropW)), y1: dmgLn[1] + 3},
+				rowY0:    nameLn[0],
+				rowY1:    dmgLn[1],
+			})
+			i += 2
+		} else {
+			i++
+		}
+	}
+	return rects
+}
+
 // mgProcessImage decodes one Marshal Guard screenshot from PNG/JPEG bytes and
 // returns the structured OCR results.
 func mgProcessImage(imageData []byte) (*MGImgResult, error) {
@@ -897,46 +1026,6 @@ func mgProcessImage(imageData []byte) (*MGImgResult, error) {
 			}
 		}
 
-		// ── Member row: 5 vsegs, hSegs[1]==3, hSegs[3]==4 ──
-		if len(vertSegs) == 5 && len(hSegs[1]) == 3 && len(hSegs[3]) == 4 {
-			rankData, err := mgCropAndBinarize(cropped, hSegs[1][1], 1)
-			if err != nil {
-				continue
-			}
-			nameData, err := mgCropAndBinarize(cropped, hSegs[3][1], 0)
-			if err != nil {
-				continue
-			}
-			dmgData, err := mgCropAndBinarize(cropped, hSegs[3][2], 2)
-			if err != nil {
-				continue
-			}
-
-			rankStr := mgReadRankDigits(rankData)
-			var rankLabel string
-			if mgRankRe.MatchString(rankStr) {
-				rankLabel = fmt.Sprintf("OK %q", rankStr)
-			} else {
-				rankLabel = fmt.Sprintf("FAIL %q", rankStr)
-			}
-
-			name, nameOK := mgOcrSegment(nameData, gosseract.PSM_SINGLE_LINE,
-				"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789[] ",
-				mgNameRe, mgNormalizeName)
-			dmg, dmgOK := mgOcrSegment(dmgData, gosseract.PSM_SINGLE_LINE,
-				"TotalDamge :0123456789.,GM", mgDamageRe, mgNormalizeDamage)
-
-			rows = append(rows, mgMemberRow{
-				rankStr: rankLabel,
-				name:    name,
-				nameOK:  nameOK,
-				dmgStr:  dmg,
-				dmgOK:   dmgOK,
-				cropY0:  float64(rect.y0+dialogY0) / float64(height),
-				cropY1:  float64(rect.y1+dialogY0) / float64(height),
-			})
-		}
-
 		// ── Datetime: 1 vseg, hSegs[0]>=2 (originally ==3, some layouts ==2) ──
 		if len(vertSegs) == 1 && len(hSegs[0]) >= 2 && result.EventDate == "" {
 			dateRe := regexp.MustCompile(`(\d{4})-(\d{1,2})-(\d{1,2})`)
@@ -957,6 +1046,49 @@ func mgProcessImage(imageData []byte) (*MGImgResult, error) {
 				}
 			}
 		}
+	}
+
+	// ── Member rows: line-detection (robust to names with spaces) ──
+	for _, r := range mgFindMemberRows(cropped, cropW, cropH) {
+		rankData, err := mgCropAndBinarize(cropped, r.rankRect, 1)
+		if err != nil {
+			continue
+		}
+		nameData, err := mgCropAndBinarize(cropped, r.nameRect, 0)
+		if err != nil {
+			continue
+		}
+		dmgData, err := mgCropAndBinarize(cropped, r.dmgRect, 2)
+		if err != nil {
+			continue
+		}
+
+		rankStr := mgReadRankDigits(rankData)
+		var rankLabel string
+		if mgRankRe.MatchString(rankStr) {
+			rankLabel = fmt.Sprintf("OK %q", rankStr)
+		} else {
+			rankLabel = fmt.Sprintf("FAIL %q", rankStr)
+		}
+
+		name, nameOK := mgOcrSegment(nameData, gosseract.PSM_SINGLE_LINE,
+			"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789[] ",
+			mgNameRe, mgNormalizeName)
+		dmg, dmgOK := mgOcrSegment(dmgData, gosseract.PSM_SINGLE_LINE,
+			"TotalDamge :0123456789.,GM", mgDamageRe, mgNormalizeDamage)
+
+		log.Printf("mg_ocr: member row y=[%d,%d] rank=%s name=%q nameOK=%v dmg=%q dmgOK=%v",
+			r.rowY0, r.rowY1, rankLabel, name, nameOK, dmg, dmgOK)
+
+		rows = append(rows, mgMemberRow{
+			rankStr: rankLabel,
+			name:    name,
+			nameOK:  nameOK,
+			dmgStr:  dmg,
+			dmgOK:   dmgOK,
+			cropY0:  float64(r.rowY0+dialogY0) / float64(height),
+			cropY1:  float64(r.rowY1+dialogY0) / float64(height),
+		})
 	}
 
 	// Reconstruct rank sequence.

--- a/mg_ocr.go
+++ b/mg_ocr.go
@@ -587,6 +587,21 @@ func mgNormalizeDamage(raw string) string {
 	return raw
 }
 
+// mgParseRawDamageInt parses a raw integer damage string using European "'"
+// thousands separators (e.g. "21'488'577'041") into int64 raw units, dropping
+// any OCR noise. Returns 0 if no digits are present.
+func mgParseRawDamageInt(raw string) int64 {
+	digits := regexp.MustCompile(`[^0-9]`).ReplaceAllString(raw, "")
+	if digits == "" {
+		return 0
+	}
+	v, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
 // mgParseDamageInt converts a "Total Damage: X.XXG/M" string to int64 (raw units).
 func mgParseDamageInt(s string) int64 {
 	m := regexp.MustCompile(`Total Damage:\s*(\d+)(?:\.(\d{1,2}))?([GM])`).FindStringSubmatch(s)
@@ -931,101 +946,6 @@ func mgProcessImage(imageData []byte) (*MGImgResult, error) {
 		}
 		log.Printf("mg_ocr: rect %v vsegs=%d hSegs=%v", rect, len(vertSegs), hLens)
 
-		// ── Top player card ──
-		// Layout A (original mg_segment): 3 vsegs, hSegs[2]>=1, hSegs[1]>=2  → name in hSegs[2][0]
-		//   damage comes from a SEPARATE rect: 3 vsegs, hSegs[1]==1, hSegs[2]==1 (handled below).
-		// Layout B (4-vseg): vseg[3] is a combined text block with both name and damage.
-		// Layout C (2-vseg): hSegs[0]>=2, hSegs[1]==1 → text area is hSegs[1][0].
-		var topNameRect, topDmgRect mgRect
-		topLayoutB := false
-		topDetected := false
-		if len(vertSegs) == 3 && len(hSegs[1]) >= 2 && len(hSegs[2]) >= 1 {
-			topNameRect = hSegs[2][0]
-			topDetected = true
-		} else if len(vertSegs) == 4 && len(hSegs) >= 4 && len(hSegs[3]) >= 1 {
-			// vseg[3] is the text area containing name and damage as a block.
-			topNameRect = hSegs[3][0]
-			topDmgRect = hSegs[3][0]
-			topLayoutB = true
-			topDetected = true
-		} else if len(vertSegs) == 2 && len(hSegs) >= 2 && len(hSegs[0]) >= 2 && len(hSegs[1]) == 1 {
-			// Layout C: 2 vsegs — left side is avatar (multi-band), right side is text block.
-			topNameRect = hSegs[1][0]
-			topDmgRect = hSegs[1][0]
-			topLayoutB = true
-			topDetected = true
-		}
-		if topDetected && result.TopPlayerName == "" {
-			data, err := mgCropAndBinarize(cropped, topNameRect, 0)
-			if err != nil {
-				log.Printf("mg_ocr: top card binarize: %v", err)
-			} else {
-				// Use SINGLE_BLOCK with no whitelist so name characters are captured.
-				raw, _ := mgRunOCR(data, gosseract.PSM_SINGLE_BLOCK, "")
-				log.Printf("mg_ocr: top card raw OCR: %q", raw)
-				for _, line := range strings.Split(raw, "\n") {
-					line = strings.TrimSpace(line)
-					if idx := strings.Index(line, "["); idx >= 0 {
-						candidate := strings.TrimSpace(line[idx:])
-						norm := mgNormalizeName(candidate)
-						if mgNameRe.MatchString(norm) {
-							result.TopPlayerName = norm
-							log.Printf("mg_ocr: top player name: %q", norm)
-							break
-						}
-					}
-				}
-				// Layout B: also try to extract damage from the same block.
-				if topLayoutB && result.TopPlayerDmgStr == "" {
-					for _, line := range strings.Split(raw, "\n") {
-						line = strings.TrimSpace(line)
-						norm := mgNormalizeDamage(line)
-						if mgDamageRe.MatchString(norm) {
-							result.TopPlayerDmgStr = mgParseDamageStr(norm)
-							result.TopPlayerDmgInt = mgParseDamageInt(norm)
-							log.Printf("mg_ocr: top damage (layout B from block): %q", norm)
-							break
-						}
-					}
-				}
-			}
-		}
-		// Top player damage from layout B/C: try all three binarise modes and keep the first
-		// non-zero result (mode 2 finds the text but can misread digits; mode 0/1 may do better).
-		if topDetected && topLayoutB && (topDmgRect != mgRect{}) && result.TopPlayerDmgStr == "" {
-			for _, bmode := range []int{2, 0, 1} {
-				data, err := mgCropAndBinarize(cropped, topDmgRect, bmode)
-				if err != nil {
-					continue
-				}
-				dmg, ok := mgOcrSegment(data, gosseract.PSM_SINGLE_LINE, "TotalDamge :0123456789.,GM", mgDamageRe, mgNormalizeDamage)
-				log.Printf("mg_ocr: top damage OCR mode=%d ok=%v %q", bmode, ok, dmg)
-				if ok && mgParseDamageInt(dmg) > 0 {
-					result.TopPlayerDmgStr = mgParseDamageStr(dmg)
-					result.TopPlayerDmgInt = mgParseDamageInt(dmg)
-					break
-				}
-			}
-			if result.TopPlayerDmgStr == "" {
-				log.Printf("mg_ocr: top damage could not be extracted for layout B/C")
-			}
-		}
-
-		// ── Top player damage row (layout A): 3 vsegs, hSegs[1]==1, hSegs[2]==1 ──
-		if len(vertSegs) == 3 && len(hSegs[1]) == 1 && len(hSegs[2]) == 1 {
-			data, err := mgCropAndBinarize(cropped, hSegs[2][0], 2)
-			if err != nil {
-				log.Printf("mg_ocr: top damage binarize: %v", err)
-				continue
-			}
-			dmg, ok := mgOcrSegment(data, gosseract.PSM_SINGLE_LINE, "TotalDamge :0123456789.,GM", mgDamageRe, mgNormalizeDamage)
-			log.Printf("mg_ocr: top damage OCR (layout A) ok=%v %q", ok, dmg)
-			if ok && result.TopPlayerDmgStr == "" {
-				result.TopPlayerDmgStr = mgParseDamageStr(dmg)
-				result.TopPlayerDmgInt = mgParseDamageInt(dmg)
-			}
-		}
-
 		// ── Datetime: 1 vseg, hSegs[0]>=2 (originally ==3, some layouts ==2) ──
 		if len(vertSegs) == 1 && len(hSegs[0]) >= 2 && result.EventDate == "" {
 			dateRe := regexp.MustCompile(`(\d{4})-(\d{1,2})-(\d{1,2})`)
@@ -1043,6 +963,52 @@ func mgProcessImage(imageData []byte) (*MGImgResult, error) {
 					result.EventDate = fmt.Sprintf("%04d-%02d-%02d", y, mo, d)
 					log.Printf("mg_ocr: event date: %q", result.EventDate)
 					break
+				}
+			}
+		}
+	}
+
+	// ── Top player card: band-based detection ──
+	// The MVP (rank 1) card near the top of the dialog shows the player name and
+	// a raw integer damage with European "'" thousands separators (e.g.
+	// 21'488'577'041). Its text band is the tallest horizontal-edge band in the
+	// upper region. Extract both directly from that band — the colour-segmentation
+	// shape matching this replaces was brittle across layouts and dropped the top
+	// card (and thus the top 3 players) entirely.
+	if bands := mgEdgeLineRuns(cropped, cropW, cropH, 0.30, 0.80, 0.16, 0.36, 20); len(bands) > 0 {
+		var topBand [2]int
+		for _, b := range bands {
+			if b[1]-b[0] > topBand[1]-topBand[0] {
+				topBand = b
+			}
+		}
+		if topBand[1]-topBand[0] >= 60 {
+			// Name: full band, contrast-stretch, first line containing the [tag].
+			nameRect := mgRect{x0: int(0.25 * float64(cropW)), y0: topBand[0], x1: int(0.88 * float64(cropW)), y1: topBand[1]}
+			if data, err := mgCropAndBinarize(cropped, nameRect, 0); err == nil {
+				raw, _ := mgRunOCR(data, gosseract.PSM_SINGLE_BLOCK, "")
+				log.Printf("mg_ocr: top card name raw OCR: %q", raw)
+				for _, line := range strings.Split(raw, "\n") {
+					if idx := strings.Index(line, "["); idx >= 0 {
+						norm := mgNormalizeName(strings.TrimSpace(line[idx:]))
+						if mgNameRe.MatchString(norm) {
+							result.TopPlayerName = norm
+							log.Printf("mg_ocr: top player name: %q", norm)
+							break
+						}
+					}
+				}
+			}
+			// Damage: the raw integer sits in a tight strip below the name line.
+			// Contrast-stretch plus a digit/apostrophe whitelist reads it consistently.
+			dmgRect := mgRect{x0: int(0.46 * float64(cropW)), y0: int(0.238 * float64(cropH)), x1: int(0.78 * float64(cropW)), y1: int(0.268 * float64(cropH))}
+			if data, err := mgCropAndBinarize(cropped, dmgRect, 0); err == nil {
+				raw, _ := mgRunOCR(data, gosseract.PSM_SINGLE_LINE, "0123456789'.,")
+				log.Printf("mg_ocr: top card damage raw OCR: %q", raw)
+				if v := mgParseRawDamageInt(raw); v > 0 {
+					result.TopPlayerDmgInt = v
+					result.TopPlayerDmgStr = mgFormatDamageStr(v)
+					log.Printf("mg_ocr: top player damage: %d (%s)", v, result.TopPlayerDmgStr)
 				}
 			}
 		}
@@ -1135,8 +1101,8 @@ func mgProcessImage(imageData []byte) (*MGImgResult, error) {
 	mgFixDamageOutliers(result.Members)
 
 	// The MVP (top card) always out-damages every listed member. If the extracted
-	// top damage is below the highest member damage, the top card was misread —
-	// discard it rather than report a wrong value.
+	// top damage is below the highest member damage, the top damage was misread —
+	// discard the damage only; the name is independently extracted and stays valid.
 	if result.TopPlayerDmgInt > 0 {
 		maxMember := int64(0)
 		for _, m := range result.Members {
@@ -1145,8 +1111,7 @@ func mgProcessImage(imageData []byte) (*MGImgResult, error) {
 			}
 		}
 		if maxMember > 0 && result.TopPlayerDmgInt < maxMember {
-			log.Printf("mg_ocr: top card implausible (%d < max member %d), discarding", result.TopPlayerDmgInt, maxMember)
-			result.TopPlayerName = ""
+			log.Printf("mg_ocr: top card damage implausible (%d < max member %d), discarding damage", result.TopPlayerDmgInt, maxMember)
 			result.TopPlayerDmgStr = ""
 			result.TopPlayerDmgInt = 0
 		}


### PR DESCRIPTION
## Problem

The Marshal Guard top card (rank 1 / MVP) was extracted with brittle colour-segmentation shape matching. Across layouts it silently dropped the card entirely, so the top players never got scanned.

## Fix

Replace the shape matching with horizontal-edge **band detection**:

- **Name**: find the tallest text band in the upper region, contrast-stretch, take the first line containing the alliance `[tag]`.
- **Damage**: the top card shows a raw integer with European `'` thousands separators (e.g. `21'488'577'041`). Read it via contrast-stretch + a digit/apostrophe whitelist and parse with the new `mgParseRawDamageInt` helper.

Also stop discarding the top player **name** when only the damage is implausible — the name is independently extracted and stays valid.

## Validation

Validated against 10 real MG screenshots: name (`[bszk]MaWis`) and damage (`21.49G`) now extract on **all 10**, with no regression to the 5 member rows per shot (ranks 2–51).