### PR TITLE
fix(ocr): parse MG member names when closing bracket is misread

### DIFF
--- a/main.go
+++ b/main.go
@@ -14725,8 +14725,9 @@ func loadAllMembers() ([]Member, error) {
 }
 
 // parsePlayerTag extracts the alliance tag and plain player name from strings like
-// "[RSRP]Gargoland" or "[RSRPlJazzyopolis" (where ] was OCR'd as l, 1, | or I).
-// knownTag (from settings) is used for fuzzy bracket matching before standard parsing.
+// "[RSRP]Gargoland" or "[RSRPlJazzyopolis" (where ] was OCR'd as l, 1, |, I, i, L,
+// J or 7). knownTag (from settings) is used for fuzzy bracket matching before
+// standard parsing.
 // getAllianceShortName returns the uppercase alliance short name from settings,
 // used as the known tag hint for player-tag parsing.
 func getAllianceShortName() string {
@@ -14746,7 +14747,14 @@ func parsePlayerTag(name, knownTag string) (tag, nameOnly string) {
 		prefix := "[" + strings.ToUpper(knownTag)
 		if idx := strings.Index(upper, prefix); idx >= 0 {
 			after := name[idx+len(prefix):]
-			if len(after) > 0 && strings.ContainsRune("]l1|I", rune(after[0])) {
+			// The closing bracket is commonly misread. Accept the usual lookalikes
+			// (lowercase "i" is the most frequent at this font size) and strip exactly
+			// one, so "[bszkinas68" → "nas68" and "[bszkiCHADOM" → "CHADOM". Names
+			// that legitimately start with one of these (e.g. "iMorocco", "Ludo 45")
+			// are still recovered: a correct "]" reads via standard parsing below, and
+			// a bracket misread to the same letter yields two letters so stripping one
+			// leaves the name's own letter intact.
+			if len(after) > 0 && strings.ContainsRune("]l1|IiLJ7", rune(after[0])) {
 				return knownTag, strings.TrimSpace(after[1:])
 			}
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,29 @@ import (
 	"testing"
 )
 
+func TestParsePlayerTag_FuzzyClosingBracket(t *testing.T) {
+	const knownTag = "bszk"
+	tests := []struct {
+		input    string
+		wantName string
+	}{
+		{"[bszk]Dopet23", "Dopet23"},
+		{"[bszk]iMorocco", "iMorocco"},
+		{"[bszk1TiC TaC", "TiC TaC"},
+		{"[bszklAlexandros 19", "Alexandros 19"},
+		{"[bszkinas68", "nas68"},
+		{"[bszkiCHADOM", "CHADOM"},
+		{"[bszkix DEUTSCHER", "x DEUTSCHER"},
+		{"[bszk]Ludo 45", "Ludo 45"},
+	}
+	for _, tt := range tests {
+		_, got := parsePlayerTag(tt.input, knownTag)
+		if got != tt.wantName {
+			t.Errorf("parsePlayerTag(%q) name = %q, want %q", tt.input, got, tt.wantName)
+		}
+	}
+}
+
 func TestNormalizeName_GermanDiacritics(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Problem

The alliance-tag closing bracket `]` is frequently misread by OCR. The known-tag fuzzy matcher in `parsePlayerTag` only accepted `]`, `l`, `1`, `|` and `I`, so when `]` rendered as lowercase `i` the whole `[bszkinas68` string was returned as the player name and member matching failed entirely.

## Fix

Add `i` (plus the other common bracket lookalikes `L`, `J`, `7`) to the accepted set and strip exactly one character after the known tag. This recovers the real roster names:

| OCR | Before | After |
|-----|--------|-------|
| `[bszkinas68` | `[bszkinas68` (no match) | `nas68` |
| `[bszkiCHADOM` | `[bszkiCHADOM` (no match) | `CHADOM` |
| `[bszkix DEUTSCHER` | `[bszkix DEUTSCHER` (no match) | `x DEUTSCHER` → `xDEUTSCHER` |

Names that legitimately start with a lookalike (e.g. `iMorocco`, `Ludo 45`) are unaffected: a correctly-read `]` is handled by standard parsing, and a bracket misread to the same letter yields two letters so stripping one leaves the name's own letter intact.

## Validation

Added `TestParsePlayerTag_FuzzyClosingBracket` covering the recovered cases plus regression cases (`iMorocco`, `Ludo 45`). Full `go build`, `go vet`, and `go test ./...` pass.